### PR TITLE
Adding search context for audit_author.identifer_ORCID (RO-2491) and

### DIFF
--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -191,7 +191,7 @@ content_info_helper_configuration:
       VERSION: 6.0.0
       INSTANCE_DATA_TYPE_INFO_FILENAME: scan-pdbx-type-map.json
     pdbx_core:
-      VERSION: 8.12.1
+      VERSION: 8.12.2
       INSTANCE_DATA_TYPE_INFO_FILENAME: scan-pdbx-type-map.json
     bird:
       VERSION: 5.2.0
@@ -1398,7 +1398,7 @@ document_helper_configuration:
         VERSION: 5.2.0
     pdbx_core:
       - NAME: pdbx_core_entry
-        VERSION: 8.11.1
+        VERSION: 8.11.2
       - NAME: pdbx_core_assembly
         VERSION: 8.4.0
       - NAME: pdbx_core_polymer_entity
@@ -3478,6 +3478,7 @@ document_helper_configuration:
           - rcsb_entry_info.branched_entity_count
           - rcsb_entry_info.cis_peptide_count
           - rcsb_entry_info.deposited_atom_count
+          - rcsb_entry_info.deposited_hydrogen_atom_count
           - rcsb_entry_info.deposited_solvent_atom_count
           - rcsb_entry_info.deposited_model_count
           - rcsb_entry_info.deposited_modeled_polymer_monomer_count
@@ -4819,6 +4820,7 @@ document_helper_configuration:
         - rcsb_entry_info.deposited_nonpolymer_entity_instance_count
         - rcsb_entry_info.deposited_polymer_monomer_count
         - rcsb_entry_info.deposited_atom_count
+        - rcsb_entry_info.deposited_hydrogen_atom_count
         - rcsb_entry_info.deposited_solvent_atom_count
         - rcsb_entry_info.deposited_model_count
         - rcsb_entry_info.disulfide_bond_count
@@ -5093,6 +5095,9 @@ document_helper_configuration:
     - ATTRIBUTE_NAME: rcsb_entry_info.deposited_atom_count
       TYPE: brief
       TEXT: Number of Non-Hydrogen Atoms per Deposited Model
+    - ATTRIBUTE_NAME: rcsb_entry_info.deposited_hydrogen_atom_count
+      TYPE: brief
+      TEXT: Number of Hydrogen Atoms per Deposited Model
     - ATTRIBUTE_NAME: rcsb_entry_info.deposited_solvent_atom_count
       TYPE: brief
       TEXT: Number of Water Molecules per Deposited Model

--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -1400,7 +1400,7 @@ document_helper_configuration:
       - NAME: pdbx_core_entry
         VERSION: 8.11.2
       - NAME: pdbx_core_assembly
-        VERSION: 8.4.0
+        VERSION: 8.4.1
       - NAME: pdbx_core_polymer_entity
         VERSION: 8.6.1
       - NAME: pdbx_core_nonpolymer_entity
@@ -3937,6 +3937,7 @@ document_helper_configuration:
           - rcsb_assembly_info.branched_atom_count
           - rcsb_assembly_info.solvent_atom_count
           - rcsb_assembly_info.atom_count
+          - rcsb_assembly_info.hydrogen_atom_count
           - rcsb_assembly_info.modeled_polymer_monomer_count
           - rcsb_assembly_info.unmodeled_polymer_monomer_count
           - rcsb_assembly_info.polymer_monomer_count
@@ -4789,6 +4790,7 @@ document_helper_configuration:
     - GROUP_NAME: Assembly Features
       ATTRIBUTE_NAMES:
       - rcsb_assembly_info.atom_count
+      - rcsb_assembly_info.hydrogen_atom_count
       - rcsb_assembly_info.solvent_atom_count
       - rcsb_assembly_info.polymer_monomer_count
       - rcsb_assembly_info.modeled_polymer_monomer_count
@@ -5011,6 +5013,9 @@ document_helper_configuration:
     - ATTRIBUTE_NAME: rcsb_assembly_info.atom_count
       TYPE: brief
       TEXT: Number of Non-Hydrogen Atoms per Assembly
+    - ATTRIBUTE_NAME: rcsb_assembly_info.hydrogen_atom_count
+      TYPE: brief
+      TEXT: Number of Hydrogen Atoms per Assembly
     - ATTRIBUTE_NAME: rcsb_assembly_info.solvent_atom_count
       TYPE: brief
       TEXT: Number of Water Molecules per Assembly

--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -4722,6 +4722,7 @@ document_helper_configuration:
         - struct.title
         - struct.pdbx_descriptor
         - audit_author.name
+        - audit_author.identifier_ORCID
         - rcsb_accession_info.deposit_date
         - rcsb_accession_info.initial_release_date
         - rcsb_accession_info.revision_date
@@ -5009,7 +5010,7 @@ document_helper_configuration:
     - ATTRIBUTE_NAME: rcsb_assembly_info.polymer_entity_instance_count
       TYPE: brief
       TEXT: Number of Polymer Instances (Chains)
-
+    #
     - ATTRIBUTE_NAME: rcsb_assembly_info.atom_count
       TYPE: brief
       TEXT: Number of Non-Hydrogen Atoms per Assembly
@@ -5195,6 +5196,9 @@ document_helper_configuration:
     - ATTRIBUTE_NAME: audit_author.name
       TYPE: brief
       TEXT: Structure Author
+    - ATTRIBUTE_NAME: audit_author.identifier_ORCID
+      TYPE: brief
+      TEXT: Structure Author ORCID
     - ATTRIBUTE_NAME: rcsb_accession_info.deposit_date
       TYPE: brief
       TEXT: Deposit Date

--- a/dictionaries/rcsb_mmcif_ext_base.dic
+++ b/dictionaries/rcsb_mmcif_ext_base.dic
@@ -4490,6 +4490,19 @@ save__rcsb_entry_info.deposited_atom_count
      2781 12968
      save_
 
+save__rcsb_entry_info.deposited_hydrogen_atom_count
+    _item_description.description
+;  The number of hydrogen atom coordinates records per deposited structure model.
+;
+    _item.name                  '_rcsb_entry_info.deposited_hydrogen_atom_count'
+    _item.category_id             rcsb_entry_info
+    _item.mandatory_code          no
+    _item_type.code               int
+    loop_
+    _item_examples.case
+     0 15301
+     save_
+
 save__rcsb_entry_info.deposited_solvent_atom_count
     _item_description.description
 ;  The number of heavy solvent atom coordinates records per deposited structure model.

--- a/dictionaries/rcsb_mmcif_ext_base.dic
+++ b/dictionaries/rcsb_mmcif_ext_base.dic
@@ -4500,7 +4500,7 @@ save__rcsb_entry_info.deposited_hydrogen_atom_count
     _item_type.code               int
     loop_
     _item_examples.case
-     0 15301
+     0 3520
      save_
 
 save__rcsb_entry_info.deposited_solvent_atom_count
@@ -5894,6 +5894,19 @@ save__rcsb_assembly_info.atom_count
        4030 223607
      save_
 #
+save__rcsb_assembly_info.hydrogen_atom_count
+    _item_description.description
+;  The assembly hydrogen atomic coordinate count.
+;
+    _item.name                  '_rcsb_assembly_info.hydrogen_atom_count'
+    _item.category_id             rcsb_assembly_info
+    _item.mandatory_code          no
+    _item_type.code               int
+    loop_
+    _item_examples.case
+       0 223607
+     save_
+
 save__rcsb_assembly_info.modeled_polymer_monomer_count
     _item_description.description
 ;  The number of modeled polymer monomers in the assembly coordinate data.

--- a/dictionaries/rcsb_mmcif_ext_base.dic
+++ b/dictionaries/rcsb_mmcif_ext_base.dic
@@ -5904,7 +5904,7 @@ save__rcsb_assembly_info.hydrogen_atom_count
     _item_type.code               int
     loop_
     _item_examples.case
-       0 223607
+       0 1760
      save_
 
 save__rcsb_assembly_info.modeled_polymer_monomer_count

--- a/dictionaries/rcsb_mmcif_ext_v1.dic
+++ b/dictionaries/rcsb_mmcif_ext_v1.dic
@@ -4490,6 +4490,19 @@ save__rcsb_entry_info.deposited_atom_count
      2781 12968
      save_
 
+save__rcsb_entry_info.deposited_hydrogen_atom_count
+    _item_description.description
+;  The number of hydrogen atom coordinates records per deposited structure model.
+;
+    _item.name                  '_rcsb_entry_info.deposited_hydrogen_atom_count'
+    _item.category_id             rcsb_entry_info
+    _item.mandatory_code          no
+    _item_type.code               int
+    loop_
+    _item_examples.case
+     0 15301
+     save_
+
 save__rcsb_entry_info.deposited_solvent_atom_count
     _item_description.description
 ;  The number of heavy solvent atom coordinates records per deposited structure model.

--- a/dictionaries/rcsb_mmcif_ext_v1.dic
+++ b/dictionaries/rcsb_mmcif_ext_v1.dic
@@ -4500,7 +4500,7 @@ save__rcsb_entry_info.deposited_hydrogen_atom_count
     _item_type.code               int
     loop_
     _item_examples.case
-     0 15301
+     0 3520
      save_
 
 save__rcsb_entry_info.deposited_solvent_atom_count
@@ -5894,6 +5894,19 @@ save__rcsb_assembly_info.atom_count
        4030 223607
      save_
 #
+save__rcsb_assembly_info.hydrogen_atom_count
+    _item_description.description
+;  The assembly hydrogen atomic coordinate count.
+;
+    _item.name                  '_rcsb_assembly_info.hydrogen_atom_count'
+    _item.category_id             rcsb_assembly_info
+    _item.mandatory_code          no
+    _item_type.code               int
+    loop_
+    _item_examples.case
+       0 223607
+     save_
+
 save__rcsb_assembly_info.modeled_polymer_monomer_count
     _item_description.description
 ;  The number of modeled polymer monomers in the assembly coordinate data.

--- a/dictionaries/rcsb_mmcif_ext_v1.dic
+++ b/dictionaries/rcsb_mmcif_ext_v1.dic
@@ -5904,7 +5904,7 @@ save__rcsb_assembly_info.hydrogen_atom_count
     _item_type.code               int
     loop_
     _item_examples.case
-       0 223607
+       0 1760
      save_
 
 save__rcsb_assembly_info.modeled_polymer_monomer_count

--- a/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_assembly.json
+++ b/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_assembly.json
@@ -276,6 +276,9 @@
             "entry_id": {
                "bsonType": "string"
             },
+            "hydrogen_atom_count": {
+               "bsonType": "int"
+            },
             "modeled_polymer_monomer_count": {
                "bsonType": "int"
             },

--- a/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -3853,6 +3853,9 @@
             "deposited_atom_count": {
                "bsonType": "int"
             },
+            "deposited_hydrogen_atom_count": {
+               "bsonType": "int"
+            },
             "deposited_model_count": {
                "bsonType": "int"
             },

--- a/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_assembly.json
+++ b/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_assembly.json
@@ -267,6 +267,9 @@
             "entry_id": {
                "bsonType": "string"
             },
+            "hydrogen_atom_count": {
+               "bsonType": "int"
+            },
             "modeled_polymer_monomer_count": {
                "bsonType": "int"
             },

--- a/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -3548,6 +3548,9 @@
             "deposited_atom_count": {
                "bsonType": "int"
             },
+            "deposited_hydrogen_atom_count": {
+               "bsonType": "int"
+            },
             "deposited_model_count": {
                "bsonType": "int"
             },

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_assembly.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_assembly.json
@@ -164,7 +164,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Assembly Features",
-                        "priority_order": 65
+                        "priority_order": 70
                      }
                   ]
                },
@@ -207,7 +207,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Assembly Features",
-                        "priority_order": 60
+                        "priority_order": 65
                      }
                   ]
                },
@@ -719,6 +719,29 @@
                   }
                ]
             },
+            "hydrogen_atom_count": {
+               "type": "integer",
+               "description": "The assembly hydrogen atomic coordinate count.",
+               "rcsb_search_context": [
+                  "default-match"
+               ],
+               "rcsb_description": [
+                  {
+                     "text": "The assembly hydrogen atomic coordinate count.",
+                     "context": "dictionary"
+                  },
+                  {
+                     "text": "Number of Hydrogen Atoms per Assembly",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Assembly Features",
+                     "priority_order": 10
+                  }
+               ]
+            },
             "modeled_polymer_monomer_count": {
                "type": "integer",
                "description": "The number of modeled polymer monomers in the assembly coordinate data.\n This is the total count of monomers with reported coordinate data for all polymer\n entity instances in the generated assembly coordinate data.",
@@ -738,7 +761,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 20
+                     "priority_order": 25
                   }
                ]
             },
@@ -833,7 +856,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 35
+                     "priority_order": 40
                   }
                ]
             },
@@ -1038,7 +1061,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 30
+                     "priority_order": 35
                   }
                ]
             },
@@ -1061,7 +1084,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 45
+                     "priority_order": 50
                   }
                ]
             },
@@ -1084,7 +1107,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 50
+                     "priority_order": 55
                   }
                ]
             },
@@ -1120,7 +1143,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 55
+                     "priority_order": 60
                   }
                ]
             },
@@ -1143,7 +1166,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 40
+                     "priority_order": 45
                   }
                ]
             },
@@ -1166,7 +1189,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 15
+                     "priority_order": 20
                   }
                ]
             },
@@ -1230,7 +1253,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 10
+                     "priority_order": 15
                   }
                ]
             },
@@ -1279,7 +1302,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 25
+                     "priority_order": 30
                   }
                ]
             }
@@ -1314,7 +1337,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_assembly.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_assembly version: 8.4.0",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_assembly version 8.4.0. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_assembly.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 8.4.0"
+   "title": "schema: pdbx_core collection: pdbx_core_assembly version: 8.4.1",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_assembly version 8.4.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_assembly.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 8.4.1"
 }

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -20,6 +20,16 @@
                      {
                         "text": "The Open Researcher and Contributor ID (ORCID).",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Structure Author ORCID",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Deposition",
+                        "priority_order": 20
                      }
                   ]
                },
@@ -5445,7 +5455,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Deposition",
-                        "priority_order": 45
+                        "priority_order": 50
                      }
                   ]
                },
@@ -5783,7 +5793,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Deposition",
-                        "priority_order": 40
+                        "priority_order": 45
                      }
                   ]
                },
@@ -5821,7 +5831,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Deposition",
-                        "priority_order": 35
+                        "priority_order": 40
                      }
                   ]
                }
@@ -6846,7 +6856,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposition",
-                     "priority_order": 55
+                     "priority_order": 60
                   }
                ]
             },
@@ -11370,7 +11380,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposition",
-                     "priority_order": 20
+                     "priority_order": 25
                   }
                ]
             },
@@ -11402,7 +11412,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposition",
-                     "priority_order": 50
+                     "priority_order": 55
                   }
                ]
             },
@@ -11430,7 +11440,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposition",
-                     "priority_order": 25
+                     "priority_order": 30
                   }
                ]
             },
@@ -11478,7 +11488,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposition",
-                     "priority_order": 30
+                     "priority_order": 35
                   }
                ]
             },
@@ -11832,6 +11842,29 @@
                   }
                ]
             },
+            "deposited_hydrogen_atom_count": {
+               "type": "integer",
+               "description": "The number of hydrogen atom coordinates records per deposited structure model.",
+               "rcsb_search_context": [
+                  "default-match"
+               ],
+               "rcsb_description": [
+                  {
+                     "text": "The number of hydrogen atom coordinates records per deposited structure model.",
+                     "context": "dictionary"
+                  },
+                  {
+                     "text": "Number of Hydrogen Atoms per Deposited Model",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Deposited Entry Features",
+                     "priority_order": 70
+                  }
+               ]
+            },
             "deposited_model_count": {
                "type": "integer",
                "description": "The number of model structures deposited.",
@@ -11851,7 +11884,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposited Entry Features",
-                     "priority_order": 75
+                     "priority_order": 80
                   }
                ]
             },
@@ -11956,7 +11989,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposited Entry Features",
-                     "priority_order": 70
+                     "priority_order": 75
                   }
                ]
             },
@@ -12044,7 +12077,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposited Entry Features",
-                     "priority_order": 80
+                     "priority_order": 85
                   }
                ]
             },
@@ -16418,7 +16451,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_entry version: 8.11.1",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 8.11.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 8.11.1"
+   "title": "schema: pdbx_core collection: pdbx_core_entry version: 8.11.2",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 8.11.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 8.11.2"
 }

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_assembly.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_assembly.json
@@ -163,7 +163,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Assembly Features",
-                        "priority_order": 65
+                        "priority_order": 70
                      }
                   ]
                },
@@ -206,7 +206,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Assembly Features",
-                        "priority_order": 60
+                        "priority_order": 65
                      }
                   ]
                },
@@ -710,6 +710,29 @@
                   }
                ]
             },
+            "hydrogen_atom_count": {
+               "type": "integer",
+               "description": "The assembly hydrogen atomic coordinate count.",
+               "rcsb_search_context": [
+                  "default-match"
+               ],
+               "rcsb_description": [
+                  {
+                     "text": "The assembly hydrogen atomic coordinate count.",
+                     "context": "dictionary"
+                  },
+                  {
+                     "text": "Number of Hydrogen Atoms per Assembly",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Assembly Features",
+                     "priority_order": 10
+                  }
+               ]
+            },
             "modeled_polymer_monomer_count": {
                "type": "integer",
                "description": "The number of modeled polymer monomers in the assembly coordinate data.\n This is the total count of monomers with reported coordinate data for all polymer\n entity instances in the generated assembly coordinate data.",
@@ -729,7 +752,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 20
+                     "priority_order": 25
                   }
                ]
             },
@@ -824,7 +847,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 35
+                     "priority_order": 40
                   }
                ]
             },
@@ -1029,7 +1052,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 30
+                     "priority_order": 35
                   }
                ]
             },
@@ -1052,7 +1075,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 45
+                     "priority_order": 50
                   }
                ]
             },
@@ -1075,7 +1098,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 50
+                     "priority_order": 55
                   }
                ]
             },
@@ -1111,7 +1134,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 55
+                     "priority_order": 60
                   }
                ]
             },
@@ -1134,7 +1157,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 40
+                     "priority_order": 45
                   }
                ]
             },
@@ -1157,7 +1180,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 15
+                     "priority_order": 20
                   }
                ]
             },
@@ -1221,7 +1244,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 10
+                     "priority_order": 15
                   }
                ]
             },
@@ -1270,7 +1293,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Assembly Features",
-                     "priority_order": 25
+                     "priority_order": 30
                   }
                ]
             }
@@ -1304,7 +1327,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_assembly.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_assembly version: 8.4.0",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_assembly version 8.4.0. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_assembly.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 8.4.0"
+   "title": "schema: pdbx_core collection: pdbx_core_assembly version: 8.4.1",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_assembly version 8.4.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_assembly.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 8.4.1"
 }

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -20,6 +20,16 @@
                      {
                         "text": "The Open Researcher and Contributor ID (ORCID).",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Structure Author ORCID",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Deposition",
+                        "priority_order": 20
                      }
                   ]
                },
@@ -5264,7 +5274,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Deposition",
-                        "priority_order": 45
+                        "priority_order": 50
                      }
                   ]
                },
@@ -5602,7 +5612,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Deposition",
-                        "priority_order": 40
+                        "priority_order": 45
                      }
                   ]
                },
@@ -5640,7 +5650,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Deposition",
-                        "priority_order": 35
+                        "priority_order": 40
                      }
                   ]
                }
@@ -6657,7 +6667,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposition",
-                     "priority_order": 55
+                     "priority_order": 60
                   }
                ]
             },
@@ -11074,7 +11084,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposition",
-                     "priority_order": 20
+                     "priority_order": 25
                   }
                ]
             },
@@ -11106,7 +11116,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposition",
-                     "priority_order": 50
+                     "priority_order": 55
                   }
                ]
             },
@@ -11134,7 +11144,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposition",
-                     "priority_order": 25
+                     "priority_order": 30
                   }
                ]
             },
@@ -11182,7 +11192,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposition",
-                     "priority_order": 30
+                     "priority_order": 35
                   }
                ]
             },
@@ -11527,6 +11537,29 @@
                   }
                ]
             },
+            "deposited_hydrogen_atom_count": {
+               "type": "integer",
+               "description": "The number of hydrogen atom coordinates records per deposited structure model.",
+               "rcsb_search_context": [
+                  "default-match"
+               ],
+               "rcsb_description": [
+                  {
+                     "text": "The number of hydrogen atom coordinates records per deposited structure model.",
+                     "context": "dictionary"
+                  },
+                  {
+                     "text": "Number of Hydrogen Atoms per Deposited Model",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Deposited Entry Features",
+                     "priority_order": 70
+                  }
+               ]
+            },
             "deposited_model_count": {
                "type": "integer",
                "description": "The number of model structures deposited.",
@@ -11546,7 +11579,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposited Entry Features",
-                     "priority_order": 75
+                     "priority_order": 80
                   }
                ]
             },
@@ -11651,7 +11684,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposited Entry Features",
-                     "priority_order": 70
+                     "priority_order": 75
                   }
                ]
             },
@@ -11735,7 +11768,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Deposited Entry Features",
-                     "priority_order": 80
+                     "priority_order": 85
                   }
                ]
             },
@@ -16009,7 +16042,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_entry version: 8.11.1",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 8.11.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 8.11.1"
+   "title": "schema: pdbx_core collection: pdbx_core_entry version: 8.11.2",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 8.11.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 8.11.2"
 }

--- a/schema_definitions/schema_def-pdbx_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_core-ANY.json
@@ -2,7 +2,7 @@
    "NAME": "pdbx_core",
    "APP_NAME": "ANY",
    "DATABASE_NAME": "pdbx_core",
-   "DATABASE_VERSION": "8.12.1",
+   "DATABASE_VERSION": "8.12.2",
    "SELECTION_FILTERS": {
       "PUBLIC_RELEASE": [
          {
@@ -62525,6 +62525,7 @@
             "BRANCHED_ATOM_COUNT": "branched_atom_count",
             "BRANCHED_ENTITY_COUNT": "branched_entity_count",
             "BRANCHED_ENTITY_INSTANCE_COUNT": "branched_entity_instance_count",
+            "HYDROGEN_ATOM_COUNT": "hydrogen_atom_count",
             "MODELED_POLYMER_MONOMER_COUNT": "modeled_polymer_monomer_count",
             "NA_POLYMER_ENTITY_TYPES": "na_polymer_entity_types",
             "NONPOLYMER_ATOM_COUNT": "nonpolymer_atom_count",
@@ -62585,6 +62586,12 @@
             "BRANCHED_ENTITY_INSTANCE_COUNT": {
                "CATEGORY": "rcsb_assembly_info",
                "ATTRIBUTE": "branched_entity_instance_count",
+               "METHOD_NAME": null,
+               "ARGUMENTS": null
+            },
+            "HYDROGEN_ATOM_COUNT": {
+               "CATEGORY": "rcsb_assembly_info",
+               "ATTRIBUTE": "hydrogen_atom_count",
                "METHOD_NAME": null,
                "ARGUMENTS": null
             },
@@ -62836,7 +62843,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "MODELED_POLYMER_MONOMER_COUNT": {
+            "HYDROGEN_ATOM_COUNT": {
                "ORDER": 7,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -62852,8 +62859,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "NA_POLYMER_ENTITY_TYPES": {
+            "MODELED_POLYMER_MONOMER_COUNT": {
                "ORDER": 8,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "NA_POLYMER_ENTITY_TYPES": {
+               "ORDER": 9,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -62875,22 +62898,6 @@
                "SUB_CATEGORIES": []
             },
             "NONPOLYMER_ATOM_COUNT": {
-               "ORDER": 9,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "NONPOLYMER_ENTITY_COUNT": {
                "ORDER": 10,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -62906,7 +62913,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "NONPOLYMER_ENTITY_INSTANCE_COUNT": {
+            "NONPOLYMER_ENTITY_COUNT": {
                "ORDER": 11,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -62922,7 +62929,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ATOM_COUNT": {
+            "NONPOLYMER_ENTITY_INSTANCE_COUNT": {
                "ORDER": 12,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -62938,8 +62945,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_COMPOSITION": {
+            "POLYMER_ATOM_COUNT": {
                "ORDER": 13,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "POLYMER_COMPOSITION": {
+               "ORDER": 14,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -62970,22 +62993,6 @@
                "SUB_CATEGORIES": []
             },
             "POLYMER_ENTITY_COUNT": {
-               "ORDER": 14,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "POLYMER_ENTITY_COUNT_DNA": {
                "ORDER": 15,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63001,7 +63008,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_RNA": {
+            "POLYMER_ENTITY_COUNT_DNA": {
                "ORDER": 16,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63017,7 +63024,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID": {
+            "POLYMER_ENTITY_COUNT_RNA": {
                "ORDER": 17,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63033,7 +63040,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID_HYBRID": {
+            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID": {
                "ORDER": 18,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63049,7 +63056,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_PROTEIN": {
+            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID_HYBRID": {
                "ORDER": 19,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63065,7 +63072,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT": {
+            "POLYMER_ENTITY_COUNT_PROTEIN": {
                "ORDER": 20,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63081,7 +63088,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT_DNA": {
+            "POLYMER_ENTITY_INSTANCE_COUNT": {
                "ORDER": 21,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63097,7 +63104,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT_RNA": {
+            "POLYMER_ENTITY_INSTANCE_COUNT_DNA": {
                "ORDER": 22,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63113,7 +63120,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT_NUCLEIC_ACID": {
+            "POLYMER_ENTITY_INSTANCE_COUNT_RNA": {
                "ORDER": 23,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63129,7 +63136,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT_NUCLEIC_ACID_HYBRID": {
+            "POLYMER_ENTITY_INSTANCE_COUNT_NUCLEIC_ACID": {
                "ORDER": 24,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63145,7 +63152,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT_PROTEIN": {
+            "POLYMER_ENTITY_INSTANCE_COUNT_NUCLEIC_ACID_HYBRID": {
                "ORDER": 25,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63161,7 +63168,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_MONOMER_COUNT": {
+            "POLYMER_ENTITY_INSTANCE_COUNT_PROTEIN": {
                "ORDER": 26,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63177,8 +63184,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "SELECTED_POLYMER_ENTITY_TYPES": {
+            "POLYMER_MONOMER_COUNT": {
                "ORDER": 27,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "SELECTED_POLYMER_ENTITY_TYPES": {
+               "ORDER": 28,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -63199,22 +63222,6 @@
                "SUB_CATEGORIES": []
             },
             "SOLVENT_ATOM_COUNT": {
-               "ORDER": 28,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "SOLVENT_ENTITY_COUNT": {
                "ORDER": 29,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63230,7 +63237,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "SOLVENT_ENTITY_INSTANCE_COUNT": {
+            "SOLVENT_ENTITY_COUNT": {
                "ORDER": 30,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63246,8 +63253,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "UNMODELED_POLYMER_MONOMER_COUNT": {
+            "SOLVENT_ENTITY_INSTANCE_COUNT": {
                "ORDER": 31,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "UNMODELED_POLYMER_MONOMER_COUNT": {
+               "ORDER": 32,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -74254,6 +74277,7 @@
             "BRANCHED_MOLECULAR_WEIGHT_MINIMUM": "branched_molecular_weight_minimum",
             "CIS_PEPTIDE_COUNT": "cis_peptide_count",
             "DEPOSITED_ATOM_COUNT": "deposited_atom_count",
+            "DEPOSITED_HYDROGEN_ATOM_COUNT": "deposited_hydrogen_atom_count",
             "DEPOSITED_MODEL_COUNT": "deposited_model_count",
             "DEPOSITED_MODELED_POLYMER_MONOMER_COUNT": "deposited_modeled_polymer_monomer_count",
             "DEPOSITED_NONPOLYMER_ENTITY_INSTANCE_COUNT": "deposited_nonpolymer_entity_instance_count",
@@ -74334,6 +74358,12 @@
             "DEPOSITED_ATOM_COUNT": {
                "CATEGORY": "rcsb_entry_info",
                "ATTRIBUTE": "deposited_atom_count",
+               "METHOD_NAME": null,
+               "ARGUMENTS": null
+            },
+            "DEPOSITED_HYDROGEN_ATOM_COUNT": {
+               "CATEGORY": "rcsb_entry_info",
+               "ATTRIBUTE": "deposited_hydrogen_atom_count",
                "METHOD_NAME": null,
                "ARGUMENTS": null
             },
@@ -74685,7 +74715,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_MODEL_COUNT": {
+            "DEPOSITED_HYDROGEN_ATOM_COUNT": {
                "ORDER": 8,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74701,7 +74731,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_MODELED_POLYMER_MONOMER_COUNT": {
+            "DEPOSITED_MODEL_COUNT": {
                "ORDER": 9,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74717,7 +74747,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_NONPOLYMER_ENTITY_INSTANCE_COUNT": {
+            "DEPOSITED_MODELED_POLYMER_MONOMER_COUNT": {
                "ORDER": 10,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74733,7 +74763,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_POLYMER_ENTITY_INSTANCE_COUNT": {
+            "DEPOSITED_NONPOLYMER_ENTITY_INSTANCE_COUNT": {
                "ORDER": 11,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74749,7 +74779,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_POLYMER_MONOMER_COUNT": {
+            "DEPOSITED_POLYMER_ENTITY_INSTANCE_COUNT": {
                "ORDER": 12,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74765,7 +74795,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_SOLVENT_ATOM_COUNT": {
+            "DEPOSITED_POLYMER_MONOMER_COUNT": {
                "ORDER": 13,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74781,7 +74811,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_UNMODELED_POLYMER_MONOMER_COUNT": {
+            "DEPOSITED_SOLVENT_ATOM_COUNT": {
                "ORDER": 14,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74797,12 +74827,12 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DIFFRN_RADIATION_WAVELENGTH_MAXIMUM": {
+            "DEPOSITED_UNMODELED_POLYMER_MONOMER_COUNT": {
                "ORDER": 15,
                "NULLABLE": true,
-               "PRECISION": 6,
+               "PRECISION": 0,
                "PRIMARY_KEY": false,
-               "APP_TYPE": "float",
+               "APP_TYPE": "int",
                "WIDTH": 10,
                "ITERABLE_DELIMITER": null,
                "FILTER_TYPES": [],
@@ -74813,7 +74843,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DIFFRN_RADIATION_WAVELENGTH_MINIMUM": {
+            "DIFFRN_RADIATION_WAVELENGTH_MAXIMUM": {
                "ORDER": 16,
                "NULLABLE": true,
                "PRECISION": 6,
@@ -74829,8 +74859,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DIFFRN_RESOLUTION_HIGH_PROVENANCE_SOURCE": {
+            "DIFFRN_RADIATION_WAVELENGTH_MINIMUM": {
                "ORDER": 17,
+               "NULLABLE": true,
+               "PRECISION": 6,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "float",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "DIFFRN_RESOLUTION_HIGH_PROVENANCE_SOURCE": {
+               "ORDER": 18,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -74852,7 +74898,7 @@
                ]
             },
             "DIFFRN_RESOLUTION_HIGH_VALUE": {
-               "ORDER": 18,
+               "ORDER": 19,
                "NULLABLE": true,
                "PRECISION": 6,
                "PRIMARY_KEY": false,
@@ -74870,22 +74916,6 @@
                ]
             },
             "DISULFIDE_BOND_COUNT": {
-               "ORDER": 19,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "ENTITY_COUNT": {
                "ORDER": 20,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74901,8 +74931,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "EXPERIMENTAL_METHOD": {
+            "ENTITY_COUNT": {
                "ORDER": 21,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "EXPERIMENTAL_METHOD": {
+               "ORDER": 22,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -74925,22 +74971,6 @@
                "SUB_CATEGORIES": []
             },
             "EXPERIMENTAL_METHOD_COUNT": {
-               "ORDER": 22,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "INTER_MOL_COVALENT_BOND_COUNT": {
                "ORDER": 23,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74956,7 +74986,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "INTER_MOL_METALIC_BOND_COUNT": {
+            "INTER_MOL_COVALENT_BOND_COUNT": {
                "ORDER": 24,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74972,8 +75002,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "MOLECULAR_WEIGHT": {
+            "INTER_MOL_METALIC_BOND_COUNT": {
                "ORDER": 25,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "MOLECULAR_WEIGHT": {
+               "ORDER": 26,
                "NULLABLE": true,
                "PRECISION": 6,
                "PRIMARY_KEY": false,
@@ -74989,7 +75035,7 @@
                "SUB_CATEGORIES": []
             },
             "NA_POLYMER_ENTITY_TYPES": {
-               "ORDER": 26,
+               "ORDER": 27,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75011,7 +75057,7 @@
                "SUB_CATEGORIES": []
             },
             "NONPOLYMER_BOUND_COMPONENTS": {
-               "ORDER": 27,
+               "ORDER": 28,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75027,7 +75073,7 @@
                "SUB_CATEGORIES": []
             },
             "NONPOLYMER_ENTITY_COUNT": {
-               "ORDER": 28,
+               "ORDER": 29,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75043,22 +75089,6 @@
                "SUB_CATEGORIES": []
             },
             "NONPOLYMER_MOLECULAR_WEIGHT_MAXIMUM": {
-               "ORDER": 29,
-               "NULLABLE": true,
-               "PRECISION": 6,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "float",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "NONPOLYMER_MOLECULAR_WEIGHT_MINIMUM": {
                "ORDER": 30,
                "NULLABLE": true,
                "PRECISION": 6,
@@ -75074,8 +75104,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_COMPOSITION": {
+            "NONPOLYMER_MOLECULAR_WEIGHT_MINIMUM": {
                "ORDER": 31,
+               "NULLABLE": true,
+               "PRECISION": 6,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "float",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "POLYMER_COMPOSITION": {
+               "ORDER": 32,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75106,22 +75152,6 @@
                "SUB_CATEGORIES": []
             },
             "POLYMER_ENTITY_COUNT": {
-               "ORDER": 32,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "POLYMER_ENTITY_COUNT_DNA": {
                "ORDER": 33,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75137,7 +75167,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_RNA": {
+            "POLYMER_ENTITY_COUNT_DNA": {
                "ORDER": 34,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75153,7 +75183,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID": {
+            "POLYMER_ENTITY_COUNT_RNA": {
                "ORDER": 35,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75169,7 +75199,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID_HYBRID": {
+            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID": {
                "ORDER": 36,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75185,7 +75215,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_PROTEIN": {
+            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID_HYBRID": {
                "ORDER": 37,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75201,7 +75231,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_TAXONOMY_COUNT": {
+            "POLYMER_ENTITY_COUNT_PROTEIN": {
                "ORDER": 38,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75217,12 +75247,12 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_MOLECULAR_WEIGHT_MAXIMUM": {
+            "POLYMER_ENTITY_TAXONOMY_COUNT": {
                "ORDER": 39,
                "NULLABLE": true,
-               "PRECISION": 6,
+               "PRECISION": 0,
                "PRIMARY_KEY": false,
-               "APP_TYPE": "float",
+               "APP_TYPE": "int",
                "WIDTH": 10,
                "ITERABLE_DELIMITER": null,
                "FILTER_TYPES": [],
@@ -75233,7 +75263,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_MOLECULAR_WEIGHT_MINIMUM": {
+            "POLYMER_MOLECULAR_WEIGHT_MAXIMUM": {
                "ORDER": 40,
                "NULLABLE": true,
                "PRECISION": 6,
@@ -75249,12 +75279,12 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_MONOMER_COUNT_MAXIMUM": {
+            "POLYMER_MOLECULAR_WEIGHT_MINIMUM": {
                "ORDER": 41,
                "NULLABLE": true,
-               "PRECISION": 0,
+               "PRECISION": 6,
                "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
+               "APP_TYPE": "float",
                "WIDTH": 10,
                "ITERABLE_DELIMITER": null,
                "FILTER_TYPES": [],
@@ -75265,7 +75295,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_MONOMER_COUNT_MINIMUM": {
+            "POLYMER_MONOMER_COUNT_MAXIMUM": {
                "ORDER": 42,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75281,8 +75311,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "RESOLUTION_COMBINED": {
+            "POLYMER_MONOMER_COUNT_MINIMUM": {
                "ORDER": 43,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "RESOLUTION_COMBINED": {
+               "ORDER": 44,
                "NULLABLE": true,
                "PRECISION": 3,
                "PRIMARY_KEY": false,
@@ -75298,7 +75344,7 @@
                "SUB_CATEGORIES": []
             },
             "SELECTED_POLYMER_ENTITY_TYPES": {
-               "ORDER": 44,
+               "ORDER": 45,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75319,7 +75365,7 @@
                "SUB_CATEGORIES": []
             },
             "SOFTWARE_PROGRAMS_COMBINED": {
-               "ORDER": 45,
+               "ORDER": 46,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75335,7 +75381,7 @@
                "SUB_CATEGORIES": []
             },
             "SOLVENT_ENTITY_COUNT": {
-               "ORDER": 46,
+               "ORDER": 47,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -100736,11 +100782,11 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "pdbx_core_entry",
-            "VERSION": "8.11.1"
+            "VERSION": "8.11.2"
          },
          {
             "NAME": "pdbx_core_assembly",
-            "VERSION": "8.4.0"
+            "VERSION": "8.4.1"
          },
          {
             "NAME": "pdbx_core_polymer_entity",

--- a/schema_definitions/schema_def-pdbx_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_core-SQL.json
@@ -2,7 +2,7 @@
    "NAME": "pdbx_core",
    "APP_NAME": "SQL",
    "DATABASE_NAME": "pdbx_core",
-   "DATABASE_VERSION": "8.12.1",
+   "DATABASE_VERSION": "8.12.2",
    "SELECTION_FILTERS": {
       "PUBLIC_RELEASE": [
          {
@@ -62525,6 +62525,7 @@
             "BRANCHED_ATOM_COUNT": "branched_atom_count",
             "BRANCHED_ENTITY_COUNT": "branched_entity_count",
             "BRANCHED_ENTITY_INSTANCE_COUNT": "branched_entity_instance_count",
+            "HYDROGEN_ATOM_COUNT": "hydrogen_atom_count",
             "MODELED_POLYMER_MONOMER_COUNT": "modeled_polymer_monomer_count",
             "NA_POLYMER_ENTITY_TYPES": "na_polymer_entity_types",
             "NONPOLYMER_ATOM_COUNT": "nonpolymer_atom_count",
@@ -62585,6 +62586,12 @@
             "BRANCHED_ENTITY_INSTANCE_COUNT": {
                "CATEGORY": "rcsb_assembly_info",
                "ATTRIBUTE": "branched_entity_instance_count",
+               "METHOD_NAME": null,
+               "ARGUMENTS": null
+            },
+            "HYDROGEN_ATOM_COUNT": {
+               "CATEGORY": "rcsb_assembly_info",
+               "ATTRIBUTE": "hydrogen_atom_count",
                "METHOD_NAME": null,
                "ARGUMENTS": null
             },
@@ -62836,7 +62843,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "MODELED_POLYMER_MONOMER_COUNT": {
+            "HYDROGEN_ATOM_COUNT": {
                "ORDER": 7,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -62852,8 +62859,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "NA_POLYMER_ENTITY_TYPES": {
+            "MODELED_POLYMER_MONOMER_COUNT": {
                "ORDER": 8,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "NA_POLYMER_ENTITY_TYPES": {
+               "ORDER": 9,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -62875,22 +62898,6 @@
                "SUB_CATEGORIES": []
             },
             "NONPOLYMER_ATOM_COUNT": {
-               "ORDER": 9,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "NONPOLYMER_ENTITY_COUNT": {
                "ORDER": 10,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -62906,7 +62913,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "NONPOLYMER_ENTITY_INSTANCE_COUNT": {
+            "NONPOLYMER_ENTITY_COUNT": {
                "ORDER": 11,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -62922,7 +62929,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ATOM_COUNT": {
+            "NONPOLYMER_ENTITY_INSTANCE_COUNT": {
                "ORDER": 12,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -62938,8 +62945,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_COMPOSITION": {
+            "POLYMER_ATOM_COUNT": {
                "ORDER": 13,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "POLYMER_COMPOSITION": {
+               "ORDER": 14,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -62970,22 +62993,6 @@
                "SUB_CATEGORIES": []
             },
             "POLYMER_ENTITY_COUNT": {
-               "ORDER": 14,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "POLYMER_ENTITY_COUNT_DNA": {
                "ORDER": 15,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63001,7 +63008,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_RNA": {
+            "POLYMER_ENTITY_COUNT_DNA": {
                "ORDER": 16,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63017,7 +63024,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID": {
+            "POLYMER_ENTITY_COUNT_RNA": {
                "ORDER": 17,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63033,7 +63040,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID_HYBRID": {
+            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID": {
                "ORDER": 18,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63049,7 +63056,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_PROTEIN": {
+            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID_HYBRID": {
                "ORDER": 19,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63065,7 +63072,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT": {
+            "POLYMER_ENTITY_COUNT_PROTEIN": {
                "ORDER": 20,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63081,7 +63088,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT_DNA": {
+            "POLYMER_ENTITY_INSTANCE_COUNT": {
                "ORDER": 21,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63097,7 +63104,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT_RNA": {
+            "POLYMER_ENTITY_INSTANCE_COUNT_DNA": {
                "ORDER": 22,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63113,7 +63120,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT_NUCLEIC_ACID": {
+            "POLYMER_ENTITY_INSTANCE_COUNT_RNA": {
                "ORDER": 23,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63129,7 +63136,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT_NUCLEIC_ACID_HYBRID": {
+            "POLYMER_ENTITY_INSTANCE_COUNT_NUCLEIC_ACID": {
                "ORDER": 24,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63145,7 +63152,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_INSTANCE_COUNT_PROTEIN": {
+            "POLYMER_ENTITY_INSTANCE_COUNT_NUCLEIC_ACID_HYBRID": {
                "ORDER": 25,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63161,7 +63168,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_MONOMER_COUNT": {
+            "POLYMER_ENTITY_INSTANCE_COUNT_PROTEIN": {
                "ORDER": 26,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63177,8 +63184,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "SELECTED_POLYMER_ENTITY_TYPES": {
+            "POLYMER_MONOMER_COUNT": {
                "ORDER": 27,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "SELECTED_POLYMER_ENTITY_TYPES": {
+               "ORDER": 28,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -63199,22 +63222,6 @@
                "SUB_CATEGORIES": []
             },
             "SOLVENT_ATOM_COUNT": {
-               "ORDER": 28,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "SOLVENT_ENTITY_COUNT": {
                "ORDER": 29,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63230,7 +63237,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "SOLVENT_ENTITY_INSTANCE_COUNT": {
+            "SOLVENT_ENTITY_COUNT": {
                "ORDER": 30,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -63246,8 +63253,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "UNMODELED_POLYMER_MONOMER_COUNT": {
+            "SOLVENT_ENTITY_INSTANCE_COUNT": {
                "ORDER": 31,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "UNMODELED_POLYMER_MONOMER_COUNT": {
+               "ORDER": 32,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -74254,6 +74277,7 @@
             "BRANCHED_MOLECULAR_WEIGHT_MINIMUM": "branched_molecular_weight_minimum",
             "CIS_PEPTIDE_COUNT": "cis_peptide_count",
             "DEPOSITED_ATOM_COUNT": "deposited_atom_count",
+            "DEPOSITED_HYDROGEN_ATOM_COUNT": "deposited_hydrogen_atom_count",
             "DEPOSITED_MODEL_COUNT": "deposited_model_count",
             "DEPOSITED_MODELED_POLYMER_MONOMER_COUNT": "deposited_modeled_polymer_monomer_count",
             "DEPOSITED_NONPOLYMER_ENTITY_INSTANCE_COUNT": "deposited_nonpolymer_entity_instance_count",
@@ -74334,6 +74358,12 @@
             "DEPOSITED_ATOM_COUNT": {
                "CATEGORY": "rcsb_entry_info",
                "ATTRIBUTE": "deposited_atom_count",
+               "METHOD_NAME": null,
+               "ARGUMENTS": null
+            },
+            "DEPOSITED_HYDROGEN_ATOM_COUNT": {
+               "CATEGORY": "rcsb_entry_info",
+               "ATTRIBUTE": "deposited_hydrogen_atom_count",
                "METHOD_NAME": null,
                "ARGUMENTS": null
             },
@@ -74685,7 +74715,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_MODEL_COUNT": {
+            "DEPOSITED_HYDROGEN_ATOM_COUNT": {
                "ORDER": 8,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74701,7 +74731,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_MODELED_POLYMER_MONOMER_COUNT": {
+            "DEPOSITED_MODEL_COUNT": {
                "ORDER": 9,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74717,7 +74747,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_NONPOLYMER_ENTITY_INSTANCE_COUNT": {
+            "DEPOSITED_MODELED_POLYMER_MONOMER_COUNT": {
                "ORDER": 10,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74733,7 +74763,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_POLYMER_ENTITY_INSTANCE_COUNT": {
+            "DEPOSITED_NONPOLYMER_ENTITY_INSTANCE_COUNT": {
                "ORDER": 11,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74749,7 +74779,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_POLYMER_MONOMER_COUNT": {
+            "DEPOSITED_POLYMER_ENTITY_INSTANCE_COUNT": {
                "ORDER": 12,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74765,7 +74795,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_SOLVENT_ATOM_COUNT": {
+            "DEPOSITED_POLYMER_MONOMER_COUNT": {
                "ORDER": 13,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74781,7 +74811,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DEPOSITED_UNMODELED_POLYMER_MONOMER_COUNT": {
+            "DEPOSITED_SOLVENT_ATOM_COUNT": {
                "ORDER": 14,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74797,12 +74827,12 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DIFFRN_RADIATION_WAVELENGTH_MAXIMUM": {
+            "DEPOSITED_UNMODELED_POLYMER_MONOMER_COUNT": {
                "ORDER": 15,
                "NULLABLE": true,
-               "PRECISION": 6,
+               "PRECISION": 0,
                "PRIMARY_KEY": false,
-               "APP_TYPE": "float",
+               "APP_TYPE": "int",
                "WIDTH": 10,
                "ITERABLE_DELIMITER": null,
                "FILTER_TYPES": [],
@@ -74813,7 +74843,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DIFFRN_RADIATION_WAVELENGTH_MINIMUM": {
+            "DIFFRN_RADIATION_WAVELENGTH_MAXIMUM": {
                "ORDER": 16,
                "NULLABLE": true,
                "PRECISION": 6,
@@ -74829,8 +74859,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "DIFFRN_RESOLUTION_HIGH_PROVENANCE_SOURCE": {
+            "DIFFRN_RADIATION_WAVELENGTH_MINIMUM": {
                "ORDER": 17,
+               "NULLABLE": true,
+               "PRECISION": 6,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "float",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "DIFFRN_RESOLUTION_HIGH_PROVENANCE_SOURCE": {
+               "ORDER": 18,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -74852,7 +74898,7 @@
                ]
             },
             "DIFFRN_RESOLUTION_HIGH_VALUE": {
-               "ORDER": 18,
+               "ORDER": 19,
                "NULLABLE": true,
                "PRECISION": 6,
                "PRIMARY_KEY": false,
@@ -74870,22 +74916,6 @@
                ]
             },
             "DISULFIDE_BOND_COUNT": {
-               "ORDER": 19,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "ENTITY_COUNT": {
                "ORDER": 20,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74901,8 +74931,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "EXPERIMENTAL_METHOD": {
+            "ENTITY_COUNT": {
                "ORDER": 21,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "EXPERIMENTAL_METHOD": {
+               "ORDER": 22,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -74925,22 +74971,6 @@
                "SUB_CATEGORIES": []
             },
             "EXPERIMENTAL_METHOD_COUNT": {
-               "ORDER": 22,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "INTER_MOL_COVALENT_BOND_COUNT": {
                "ORDER": 23,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74956,7 +74986,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "INTER_MOL_METALIC_BOND_COUNT": {
+            "INTER_MOL_COVALENT_BOND_COUNT": {
                "ORDER": 24,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -74972,8 +75002,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "MOLECULAR_WEIGHT": {
+            "INTER_MOL_METALIC_BOND_COUNT": {
                "ORDER": 25,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "MOLECULAR_WEIGHT": {
+               "ORDER": 26,
                "NULLABLE": true,
                "PRECISION": 6,
                "PRIMARY_KEY": false,
@@ -74989,7 +75035,7 @@
                "SUB_CATEGORIES": []
             },
             "NA_POLYMER_ENTITY_TYPES": {
-               "ORDER": 26,
+               "ORDER": 27,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75011,7 +75057,7 @@
                "SUB_CATEGORIES": []
             },
             "NONPOLYMER_BOUND_COMPONENTS": {
-               "ORDER": 27,
+               "ORDER": 28,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75027,7 +75073,7 @@
                "SUB_CATEGORIES": []
             },
             "NONPOLYMER_ENTITY_COUNT": {
-               "ORDER": 28,
+               "ORDER": 29,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75043,22 +75089,6 @@
                "SUB_CATEGORIES": []
             },
             "NONPOLYMER_MOLECULAR_WEIGHT_MAXIMUM": {
-               "ORDER": 29,
-               "NULLABLE": true,
-               "PRECISION": 6,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "float",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "NONPOLYMER_MOLECULAR_WEIGHT_MINIMUM": {
                "ORDER": 30,
                "NULLABLE": true,
                "PRECISION": 6,
@@ -75074,8 +75104,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_COMPOSITION": {
+            "NONPOLYMER_MOLECULAR_WEIGHT_MINIMUM": {
                "ORDER": 31,
+               "NULLABLE": true,
+               "PRECISION": 6,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "float",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "POLYMER_COMPOSITION": {
+               "ORDER": 32,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75106,22 +75152,6 @@
                "SUB_CATEGORIES": []
             },
             "POLYMER_ENTITY_COUNT": {
-               "ORDER": 32,
-               "NULLABLE": true,
-               "PRECISION": 0,
-               "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
-               "WIDTH": 10,
-               "ITERABLE_DELIMITER": null,
-               "FILTER_TYPES": [],
-               "IS_CHAR_TYPE": false,
-               "ENUMERATION": [],
-               "CONTENT_CLASSES": [
-                  "GENERATED_CONTENT"
-               ],
-               "SUB_CATEGORIES": []
-            },
-            "POLYMER_ENTITY_COUNT_DNA": {
                "ORDER": 33,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75137,7 +75167,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_RNA": {
+            "POLYMER_ENTITY_COUNT_DNA": {
                "ORDER": 34,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75153,7 +75183,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID": {
+            "POLYMER_ENTITY_COUNT_RNA": {
                "ORDER": 35,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75169,7 +75199,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID_HYBRID": {
+            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID": {
                "ORDER": 36,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75185,7 +75215,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_COUNT_PROTEIN": {
+            "POLYMER_ENTITY_COUNT_NUCLEIC_ACID_HYBRID": {
                "ORDER": 37,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75201,7 +75231,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_ENTITY_TAXONOMY_COUNT": {
+            "POLYMER_ENTITY_COUNT_PROTEIN": {
                "ORDER": 38,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75217,12 +75247,12 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_MOLECULAR_WEIGHT_MAXIMUM": {
+            "POLYMER_ENTITY_TAXONOMY_COUNT": {
                "ORDER": 39,
                "NULLABLE": true,
-               "PRECISION": 6,
+               "PRECISION": 0,
                "PRIMARY_KEY": false,
-               "APP_TYPE": "float",
+               "APP_TYPE": "int",
                "WIDTH": 10,
                "ITERABLE_DELIMITER": null,
                "FILTER_TYPES": [],
@@ -75233,7 +75263,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_MOLECULAR_WEIGHT_MINIMUM": {
+            "POLYMER_MOLECULAR_WEIGHT_MAXIMUM": {
                "ORDER": 40,
                "NULLABLE": true,
                "PRECISION": 6,
@@ -75249,12 +75279,12 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_MONOMER_COUNT_MAXIMUM": {
+            "POLYMER_MOLECULAR_WEIGHT_MINIMUM": {
                "ORDER": 41,
                "NULLABLE": true,
-               "PRECISION": 0,
+               "PRECISION": 6,
                "PRIMARY_KEY": false,
-               "APP_TYPE": "int",
+               "APP_TYPE": "float",
                "WIDTH": 10,
                "ITERABLE_DELIMITER": null,
                "FILTER_TYPES": [],
@@ -75265,7 +75295,7 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "POLYMER_MONOMER_COUNT_MINIMUM": {
+            "POLYMER_MONOMER_COUNT_MAXIMUM": {
                "ORDER": 42,
                "NULLABLE": true,
                "PRECISION": 0,
@@ -75281,8 +75311,24 @@
                ],
                "SUB_CATEGORIES": []
             },
-            "RESOLUTION_COMBINED": {
+            "POLYMER_MONOMER_COUNT_MINIMUM": {
                "ORDER": 43,
+               "NULLABLE": true,
+               "PRECISION": 0,
+               "PRIMARY_KEY": false,
+               "APP_TYPE": "int",
+               "WIDTH": 10,
+               "ITERABLE_DELIMITER": null,
+               "FILTER_TYPES": [],
+               "IS_CHAR_TYPE": false,
+               "ENUMERATION": [],
+               "CONTENT_CLASSES": [
+                  "GENERATED_CONTENT"
+               ],
+               "SUB_CATEGORIES": []
+            },
+            "RESOLUTION_COMBINED": {
+               "ORDER": 44,
                "NULLABLE": true,
                "PRECISION": 3,
                "PRIMARY_KEY": false,
@@ -75298,7 +75344,7 @@
                "SUB_CATEGORIES": []
             },
             "SELECTED_POLYMER_ENTITY_TYPES": {
-               "ORDER": 44,
+               "ORDER": 45,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75319,7 +75365,7 @@
                "SUB_CATEGORIES": []
             },
             "SOFTWARE_PROGRAMS_COMBINED": {
-               "ORDER": 45,
+               "ORDER": 46,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -75335,7 +75381,7 @@
                "SUB_CATEGORIES": []
             },
             "SOLVENT_ENTITY_COUNT": {
-               "ORDER": 46,
+               "ORDER": 47,
                "NULLABLE": true,
                "PRECISION": 0,
                "PRIMARY_KEY": false,
@@ -100736,11 +100782,11 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "pdbx_core_entry",
-            "VERSION": "8.11.1"
+            "VERSION": "8.11.2"
          },
          {
             "NAME": "pdbx_core_assembly",
-            "VERSION": "8.4.0"
+            "VERSION": "8.4.1"
          },
          {
             "NAME": "pdbx_core_polymer_entity",


### PR DESCRIPTION
hydrogen atom count for entries and assemblies (RO-2489).