### PR TITLE
RO-2584 add search context for rcsb_repository_holdings_current.repository_content_types, and RO-2503 suppress entry_id and entity_id in rcsb_related_target_references/rcsb_target_cofactors.

### DIFF
--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -102,6 +102,8 @@
 #                                        rcsb_entity_source_organism.ncbi_parent_scientific_name
 #                                        rcsb_entity_source_organism.source_type
 #                 extend enum for _rcsb_target_cofactors.binding_assay_value_type
+# 12-Aug-2021  jdw RO-2584 add search context for rcsb_repository_holdings_current.repository_content_types, and
+#                  RO-2503 suppress entry_id and entity_id in rcsb_related_target_references/rcsb_target_cofactors.
 # -
 ---
 database_catalog_configuration:
@@ -195,7 +197,7 @@ content_info_helper_configuration:
       VERSION: 6.0.0
       INSTANCE_DATA_TYPE_INFO_FILENAME: scan-pdbx-type-map.json
     pdbx_core:
-      VERSION: 9.3.0
+      VERSION: 9.3.1
       INSTANCE_DATA_TYPE_INFO_FILENAME: scan-pdbx-type-map.json
     bird:
       VERSION: 5.2.0
@@ -216,7 +218,7 @@ content_info_helper_configuration:
       VERSION: 1.1.0
       INSTANCE_DATA_TYPE_INFO_FILENAME:
     repository_holdings:
-      VERSION: 7.8.0
+      VERSION: 7.8.1
       INSTANCE_DATA_TYPE_INFO_FILENAME:
     sequence_clusters:
       VERSION: 5.6.0
@@ -1424,7 +1426,7 @@ document_helper_configuration:
       - NAME: pdbx_core_assembly
         VERSION: 8.5.0
       - NAME: pdbx_core_polymer_entity
-        VERSION: 9.2.0
+        VERSION: 9.2.1
       - NAME: pdbx_core_nonpolymer_entity
         VERSION: 9.2.0
       - NAME: pdbx_core_branched_entity
@@ -1457,7 +1459,7 @@ document_helper_configuration:
       - NAME: repository_holdings_combined_entry
         VERSION: 1.0.0
       - NAME: repository_holdings_current_entry
-        VERSION: 3.4.0
+        VERSION: 3.4.1
       - NAME: repository_holdings_unreleased_entry
         VERSION: 3.5.0
       - NAME: repository_holdings_removed_entry
@@ -4179,6 +4181,12 @@ document_helper_configuration:
           - drugbank_target.organism_common_name
           - drugbank_target.target_actions
     #
+    #
+    repository_holdings_current_entry:
+      - SEARCH_TYPE: exact-match
+        ATTRIBUTE_NAMES:
+          - rcsb_repository_holdings_current.repository_content_types
+    #
     repository_holdings_removed_entry:
       - SEARCH_TYPE: suggest
         ATTRIBUTE_NAMES:
@@ -4423,6 +4431,16 @@ document_helper_configuration:
           - entity_id
           - entry_id
           - ordinal
+      - CATEGORY_NAME: rcsb_related_target_references
+        ATTRIBUTE_NAME_LIST:
+          - ordinal
+          - entity_id
+          - entry_id
+      - CATEGORY_NAME: rcsb_target_cofactors
+        ATTRIBUTE_NAME_LIST:
+          - ordinal
+          - entity_id
+          - entry_id
       - CATEGORY_NAME: entity
         ATTRIBUTE_NAME_LIST:
           - id

--- a/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -1117,15 +1117,6 @@
          "items": {
             "bsonType": "object",
             "properties": {
-               "entity_id": {
-                  "bsonType": "string"
-               },
-               "entry_id": {
-                  "bsonType": "string"
-               },
-               "ordinal": {
-                  "bsonType": "int"
-               },
                "related_resource_name": {
                   "bsonType": "string",
                   "enum": [
@@ -1165,9 +1156,6 @@
             },
             "additionalProperties": false,
             "required": [
-               "entity_id",
-               "entry_id",
-               "ordinal",
                "related_resource_name",
                "related_target_id"
             ]
@@ -1214,12 +1202,6 @@
                "cofactor_resource_id": {
                   "bsonType": "string"
                },
-               "entity_id": {
-                  "bsonType": "string"
-               },
-               "entry_id": {
-                  "bsonType": "string"
-               },
                "mechanism_of_action": {
                   "bsonType": "string"
                },
@@ -1229,9 +1211,6 @@
                      "N",
                      "Y"
                   ]
-               },
-               "ordinal": {
-                  "bsonType": "int"
                },
                "patent_nos": {
                   "bsonType": "array",
@@ -1265,9 +1244,6 @@
             "additionalProperties": false,
             "required": [
                "cofactor_resource_id",
-               "entity_id",
-               "entry_id",
-               "ordinal",
                "resource_name",
                "target_resource_id"
             ]

--- a/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -1093,15 +1093,6 @@
          "items": {
             "bsonType": "object",
             "properties": {
-               "entity_id": {
-                  "bsonType": "string"
-               },
-               "entry_id": {
-                  "bsonType": "string"
-               },
-               "ordinal": {
-                  "bsonType": "int"
-               },
                "related_resource_name": {
                   "bsonType": "string",
                   "enum": [
@@ -1139,10 +1130,7 @@
                   "uniqueItems": false
                }
             },
-            "additionalProperties": false,
-            "required": [
-               "ordinal"
-            ]
+            "additionalProperties": false
          },
          "minItems": 1,
          "uniqueItems": true
@@ -1186,12 +1174,6 @@
                "cofactor_resource_id": {
                   "bsonType": "string"
                },
-               "entity_id": {
-                  "bsonType": "string"
-               },
-               "entry_id": {
-                  "bsonType": "string"
-               },
                "mechanism_of_action": {
                   "bsonType": "string"
                },
@@ -1201,9 +1183,6 @@
                      "N",
                      "Y"
                   ]
-               },
-               "ordinal": {
-                  "bsonType": "int"
                },
                "patent_nos": {
                   "bsonType": "array",
@@ -1234,10 +1213,7 @@
                   "bsonType": "string"
                }
             },
-            "additionalProperties": false,
-            "required": [
-               "ordinal"
-            ]
+            "additionalProperties": false
          },
          "minItems": 1,
          "uniqueItems": true

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -4135,42 +4135,6 @@
          "items": {
             "type": "object",
             "properties": {
-               "entity_id": {
-                  "type": "string",
-                  "examples": [
-                     "1"
-                  ],
-                  "description": "Entity identifier for the polymer.",
-                  "rcsb_description": [
-                     {
-                        "text": "Entity identifier for the polymer.",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
-               "entry_id": {
-                  "type": "string",
-                  "examples": [
-                     "1ABC"
-                  ],
-                  "description": "Structure entry identifier.",
-                  "rcsb_description": [
-                     {
-                        "text": "Structure entry identifier.",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
-               "ordinal": {
-                  "type": "integer",
-                  "description": "Ordinal identifier for this category",
-                  "rcsb_description": [
-                     {
-                        "text": "Ordinal identifier for this category",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
                "related_resource_name": {
                   "type": "string",
                   "enum": [
@@ -4284,9 +4248,6 @@
             },
             "additionalProperties": false,
             "required": [
-               "entity_id",
-               "entry_id",
-               "ordinal",
                "related_resource_name",
                "related_target_id"
             ]
@@ -4458,32 +4419,6 @@
                      }
                   ]
                },
-               "entity_id": {
-                  "type": "string",
-                  "examples": [
-                     "1"
-                  ],
-                  "description": "Entity identifier for the polymer.",
-                  "rcsb_description": [
-                     {
-                        "text": "Entity identifier for the polymer.",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
-               "entry_id": {
-                  "type": "string",
-                  "examples": [
-                     "1ABC"
-                  ],
-                  "description": "Structure entry identifier.",
-                  "rcsb_description": [
-                     {
-                        "text": "Structure entry identifier.",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
                "mechanism_of_action": {
                   "type": "string",
                   "examples": [
@@ -4523,16 +4458,6 @@
                   "rcsb_description": [
                      {
                         "text": "A flag to indicate the cofactor is a structural neighbor of this\n entity.",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
-               "ordinal": {
-                  "type": "integer",
-                  "description": "Ordinal identifier for this category",
-                  "rcsb_description": [
-                     {
-                        "text": "Ordinal identifier for this category",
                         "context": "dictionary"
                      }
                   ]
@@ -4636,9 +4561,6 @@
             "additionalProperties": false,
             "required": [
                "cofactor_resource_id",
-               "entity_id",
-               "entry_id",
-               "ordinal",
                "resource_name",
                "target_resource_id"
             ]
@@ -4670,7 +4592,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_polymer_entity.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity version: 9.2.0",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity version 9.2.0. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_polymer_entity.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 9.2.0"
+   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity version: 9.2.1",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity version 9.2.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_polymer_entity.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 9.2.1"
 }

--- a/json_schema_definitions/json-full-db-repository_holdings-col-repository_holdings_current_entry.json
+++ b/json_schema_definitions/json-full-db-repository_holdings-col-repository_holdings_current_entry.json
@@ -33,6 +33,10 @@
                      "entry mmCIF"
                   ],
                   "description": "The list of content types associated with this entry.",
+                  "rcsb_search_context": [
+                     "exact-match"
+                  ],
+                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "The list of content types associated with this entry.",
@@ -137,7 +141,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-repository_holdings_current_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: repository_holdings collection: repository_holdings_current_entry version: 3.4.0",
-   "description": "RCSB Exchange Database JSON schema derived from the repository_holdings content type schema. This schema supports collection repository_holdings_current_entry version 3.4.0. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-repository_holdings_current_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 3.4.0"
+   "title": "schema: repository_holdings collection: repository_holdings_current_entry version: 3.4.1",
+   "description": "RCSB Exchange Database JSON schema derived from the repository_holdings content type schema. This schema supports collection repository_holdings_current_entry version 3.4.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-repository_holdings_current_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 3.4.1"
 }

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -4111,42 +4111,6 @@
          "items": {
             "type": "object",
             "properties": {
-               "entity_id": {
-                  "type": "string",
-                  "examples": [
-                     "1"
-                  ],
-                  "description": "Entity identifier for the polymer.",
-                  "rcsb_description": [
-                     {
-                        "text": "Entity identifier for the polymer.",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
-               "entry_id": {
-                  "type": "string",
-                  "examples": [
-                     "1ABC"
-                  ],
-                  "description": "Structure entry identifier.",
-                  "rcsb_description": [
-                     {
-                        "text": "Structure entry identifier.",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
-               "ordinal": {
-                  "type": "integer",
-                  "description": "Ordinal identifier for this category",
-                  "rcsb_description": [
-                     {
-                        "text": "Ordinal identifier for this category",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
                "related_resource_name": {
                   "type": "string",
                   "enum": [
@@ -4258,10 +4222,7 @@
                   "uniqueItems": false
                }
             },
-            "additionalProperties": false,
-            "required": [
-               "ordinal"
-            ]
+            "additionalProperties": false
          },
          "minItems": 1,
          "uniqueItems": true
@@ -4430,32 +4391,6 @@
                      }
                   ]
                },
-               "entity_id": {
-                  "type": "string",
-                  "examples": [
-                     "1"
-                  ],
-                  "description": "Entity identifier for the polymer.",
-                  "rcsb_description": [
-                     {
-                        "text": "Entity identifier for the polymer.",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
-               "entry_id": {
-                  "type": "string",
-                  "examples": [
-                     "1ABC"
-                  ],
-                  "description": "Structure entry identifier.",
-                  "rcsb_description": [
-                     {
-                        "text": "Structure entry identifier.",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
                "mechanism_of_action": {
                   "type": "string",
                   "examples": [
@@ -4495,16 +4430,6 @@
                   "rcsb_description": [
                      {
                         "text": "A flag to indicate the cofactor is a structural neighbor of this\n entity.",
-                        "context": "dictionary"
-                     }
-                  ]
-               },
-               "ordinal": {
-                  "type": "integer",
-                  "description": "Ordinal identifier for this category",
-                  "rcsb_description": [
-                     {
-                        "text": "Ordinal identifier for this category",
                         "context": "dictionary"
                      }
                   ]
@@ -4605,10 +4530,7 @@
                   ]
                }
             },
-            "additionalProperties": false,
-            "required": [
-               "ordinal"
-            ]
+            "additionalProperties": false
          },
          "minItems": 1,
          "uniqueItems": true
@@ -4637,7 +4559,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_polymer_entity.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity version: 9.2.0",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity version 9.2.0. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_polymer_entity.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 9.2.0"
+   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity version: 9.2.1",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity version 9.2.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_polymer_entity.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 9.2.1"
 }

--- a/json_schema_definitions/json-min-db-repository_holdings-col-repository_holdings_current_entry.json
+++ b/json_schema_definitions/json-min-db-repository_holdings-col-repository_holdings_current_entry.json
@@ -33,6 +33,10 @@
                      "entry mmCIF"
                   ],
                   "description": "The list of content types associated with this entry.",
+                  "rcsb_search_context": [
+                     "exact-match"
+                  ],
+                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "The list of content types associated with this entry.",
@@ -132,7 +136,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-repository_holdings_current_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: repository_holdings collection: repository_holdings_current_entry version: 3.4.0",
-   "description": "RCSB Exchange Database JSON schema derived from the repository_holdings content type schema. This schema supports collection repository_holdings_current_entry version 3.4.0. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-repository_holdings_current_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 3.4.0"
+   "title": "schema: repository_holdings collection: repository_holdings_current_entry version: 3.4.1",
+   "description": "RCSB Exchange Database JSON schema derived from the repository_holdings content type schema. This schema supports collection repository_holdings_current_entry version 3.4.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-repository_holdings_current_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 3.4.1"
 }

--- a/schema_definitions/schema_def-pdbx_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_core-ANY.json
@@ -2,7 +2,7 @@
    "NAME": "pdbx_core",
    "APP_NAME": "ANY",
    "DATABASE_NAME": "pdbx_core",
-   "DATABASE_VERSION": "9.3.0",
+   "DATABASE_VERSION": "9.3.1",
    "SELECTION_FILTERS": {
       "PUBLIC_RELEASE": [
          {
@@ -107647,7 +107647,7 @@
          },
          {
             "NAME": "pdbx_core_polymer_entity",
-            "VERSION": "9.2.0"
+            "VERSION": "9.2.1"
          },
          {
             "NAME": "pdbx_core_nonpolymer_entity",
@@ -108455,6 +108455,16 @@
                   "entity_id",
                   "entry_id",
                   "ordinal"
+               ],
+               "rcsb_related_target_references": [
+                  "ordinal",
+                  "entity_id",
+                  "entry_id"
+               ],
+               "rcsb_target_cofactors": [
+                  "ordinal",
+                  "entity_id",
+                  "entry_id"
                ],
                "entity": [
                   "id",

--- a/schema_definitions/schema_def-pdbx_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_core-SQL.json
@@ -2,7 +2,7 @@
    "NAME": "pdbx_core",
    "APP_NAME": "SQL",
    "DATABASE_NAME": "pdbx_core",
-   "DATABASE_VERSION": "9.3.0",
+   "DATABASE_VERSION": "9.3.1",
    "SELECTION_FILTERS": {
       "PUBLIC_RELEASE": [
          {
@@ -107647,7 +107647,7 @@
          },
          {
             "NAME": "pdbx_core_polymer_entity",
-            "VERSION": "9.2.0"
+            "VERSION": "9.2.1"
          },
          {
             "NAME": "pdbx_core_nonpolymer_entity",
@@ -108455,6 +108455,16 @@
                   "entity_id",
                   "entry_id",
                   "ordinal"
+               ],
+               "rcsb_related_target_references": [
+                  "ordinal",
+                  "entity_id",
+                  "entry_id"
+               ],
+               "rcsb_target_cofactors": [
+                  "ordinal",
+                  "entity_id",
+                  "entry_id"
                ],
                "entity": [
                   "id",

--- a/schema_definitions/schema_def-repository_holdings-ANY.json
+++ b/schema_definitions/schema_def-repository_holdings-ANY.json
@@ -2,7 +2,7 @@
    "NAME": "repository_holdings",
    "APP_NAME": "ANY",
    "DATABASE_NAME": "repository_holdings",
-   "DATABASE_VERSION": "7.8.0",
+   "DATABASE_VERSION": "7.8.1",
    "SELECTION_FILTERS": {},
    "SCHEMA_DICT": {
       "RCSB_REPOSITORY_HOLDINGS_COMBINED": {
@@ -3018,7 +3018,7 @@
          },
          {
             "NAME": "repository_holdings_current_entry",
-            "VERSION": "3.4.0"
+            "VERSION": "3.4.1"
          },
          {
             "NAME": "repository_holdings_unreleased_entry",

--- a/schema_definitions/schema_def-repository_holdings-SQL.json
+++ b/schema_definitions/schema_def-repository_holdings-SQL.json
@@ -2,7 +2,7 @@
    "NAME": "repository_holdings",
    "APP_NAME": "SQL",
    "DATABASE_NAME": "repository_holdings",
-   "DATABASE_VERSION": "7.8.0",
+   "DATABASE_VERSION": "7.8.1",
    "SELECTION_FILTERS": {},
    "SCHEMA_DICT": {
       "RCSB_REPOSITORY_HOLDINGS_COMBINED": {
@@ -3018,7 +3018,7 @@
          },
          {
             "NAME": "repository_holdings_current_entry",
-            "VERSION": "3.4.0"
+            "VERSION": "3.4.1"
          },
          {
             "NAME": "repository_holdings_unreleased_entry",


### PR DESCRIPTION
RO-2584 add search context for rcsb_repository_holdings_current.repository_content_types, and RO-2503 suppress entry_id and entity_id in rcsb_related_target_references/rcsb_target_cofactors.