### PR TITLE
RO-2595: Remove internal _struct.pdbx_descriptor from schema

### DIFF
--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -140,6 +140,7 @@
 #                  RO-3843: Add drugbank_info.brand_names to advanced search menu
 # 28-Mar-2023   bv Update document collection versions
 # 19-Apr-2023   bv Remove internal VRPT_DICT_LOCATOR and corresponding categories from schema
+# 17-Jul-2023  dwp Remove internal _struct.pdbx_descriptor from schema
 # 
 ---
 database_catalog_configuration:
@@ -2783,6 +2784,7 @@ document_helper_configuration:
       - CATEGORY_NAME: struct
         ATTRIBUTE_NAME_LIST:
           - entry_id
+          - pdbx_descriptor
       - CATEGORY_NAME: struct_keywords
         ATTRIBUTE_NAME_LIST:
           - entry_id

--- a/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -4801,9 +4801,6 @@
                   "Y"
                ]
             },
-            "pdbx_descriptor": {
-               "bsonType": "string"
-            },
             "pdbx_model_details": {
                "bsonType": "string"
             },

--- a/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -4401,9 +4401,6 @@
                   "Y"
                ]
             },
-            "pdbx_descriptor": {
-               "bsonType": "string"
-            },
             "pdbx_model_details": {
                "bsonType": "string"
             },

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -15686,21 +15686,6 @@
                   }
                ]
             },
-            "pdbx_descriptor": {
-               "type": "string",
-               "examples": [
-                  "Cytochrome b5",
-                  "Regulatory protein RecX",
-                  "Uridine kinase (E.C.2.7.1.48)"
-               ],
-               "description": "An automatically generated descriptor for an NDB structure or\n the unstructured content of the PDB COMPND record.",
-               "rcsb_description": [
-                  {
-                     "text": "An automatically generated descriptor for an NDB structure or\n the unstructured content of the PDB COMPND record.",
-                     "context": "dictionary"
-                  }
-               ]
-            },
             "pdbx_model_details": {
                "type": "string",
                "examples": [

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -15286,21 +15286,6 @@
                   }
                ]
             },
-            "pdbx_descriptor": {
-               "type": "string",
-               "examples": [
-                  "Cytochrome b5",
-                  "Regulatory protein RecX",
-                  "Uridine kinase (E.C.2.7.1.48)"
-               ],
-               "description": "An automatically generated descriptor for an NDB structure or\n the unstructured content of the PDB COMPND record.",
-               "rcsb_description": [
-                  {
-                     "text": "An automatically generated descriptor for an NDB structure or\n the unstructured content of the PDB COMPND record.",
-                     "context": "dictionary"
-                  }
-               ]
-            },
             "pdbx_model_details": {
                "type": "string",
                "examples": [

--- a/schema_definitions/schema_def-pdbx_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_core-ANY.json
@@ -100454,7 +100454,8 @@
                   "entry_id"
                ],
                "struct": [
-                  "entry_id"
+                  "entry_id",
+                  "pdbx_descriptor"
                ],
                "struct_keywords": [
                   "entry_id"

--- a/schema_definitions/schema_def-pdbx_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_core-SQL.json
@@ -100454,7 +100454,8 @@
                   "entry_id"
                ],
                "struct": [
-                  "entry_id"
+                  "entry_id",
+                  "pdbx_descriptor"
                ],
                "struct_keywords": [
                   "entry_id"


### PR DESCRIPTION
[RO-2595](https://rcsbpdb.atlassian.net/browse/RO-2595): Remove internal `_struct.pdbx_descriptor` from schema