### PR TITLE
Update ExDB schemas for RO-3904 and RO-4002

### DIFF
--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -140,6 +140,8 @@
 #                  RO-3843: Add drugbank_info.brand_names to advanced search menu
 # 28-Mar-2023   bv Update document collection versions
 # 19-Apr-2023   bv Remove internal VRPT_DICT_LOCATOR and corresponding categories from schema
+# 26-Jul-2023   bv RO-3904: Add UI metadata for Pfam protein family name
+#                  RO-4002: Improve indexing for pdbx_initial_refinement_model
 # 
 ---
 database_catalog_configuration:
@@ -3941,6 +3943,8 @@ document_helper_configuration:
         NAME: citations_all
       - CATEGORY: pdbx_database_related
         NAME: database_related
+      - CATEGORY: pdbx_initial_refinement_model
+        NAME: initial_refinement_model
       #- CATEGORY: database_2
       #  NAME: database_2
     pdbx_core_polymer_entity: &ccn_pdbx_core_polymer_entity
@@ -5521,6 +5525,7 @@ document_helper_configuration:
         - rcsb_polymer_entity.rcsb_ec_lineage_name
         #
         - rcsb_polymer_entity_annotation.annotation_id
+        - rcsb_polymer_entity_annotation.name
         - rcsb_polymer_entity_annotation.annotation_lineage_id
         - rcsb_polymer_entity_annotation.annotation_lineage_name
         #

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -7719,7 +7719,8 @@
             ]
          },
          "minItems": 1,
-         "uniqueItems": true
+         "uniqueItems": true,
+         "rcsb_nested_indexing": true
       },
       "pdbx_molecule_features": {
          "type": "array",

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
@@ -2745,6 +2745,12 @@
                         "text": "Name",
                         "context": "brief"
                      }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 105
+                     }
                   ]
                },
                "provenance_source": {
@@ -2893,7 +2899,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 105
+                                 "priority_order": 110
                               }
                            ]
                         },
@@ -2918,7 +2924,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 110
+                                 "priority_order": 115
                               }
                            ]
                         }
@@ -3902,7 +3908,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 115
+                        "priority_order": 120
                      }
                   ]
                },
@@ -3929,7 +3935,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 120
+                        "priority_order": 125
                      }
                   ]
                },

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -7719,7 +7719,8 @@
             ]
          },
          "minItems": 1,
-         "uniqueItems": true
+         "uniqueItems": true,
+         "rcsb_nested_indexing": true
       },
       "pdbx_molecule_features": {
          "type": "array",

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -2745,6 +2745,12 @@
                         "text": "Name",
                         "context": "brief"
                      }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 105
+                     }
                   ]
                },
                "provenance_source": {
@@ -2893,7 +2899,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 105
+                                 "priority_order": 110
                               }
                            ]
                         },
@@ -2918,7 +2924,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 110
+                                 "priority_order": 115
                               }
                            ]
                         }
@@ -3902,7 +3908,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 115
+                        "priority_order": 120
                      }
                   ]
                },
@@ -3929,7 +3935,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 120
+                        "priority_order": 125
                      }
                   ]
                },

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -7512,7 +7512,8 @@
             ]
          },
          "minItems": 1,
-         "uniqueItems": true
+         "uniqueItems": true,
+         "rcsb_nested_indexing": true
       },
       "pdbx_molecule_features": {
          "type": "array",

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
@@ -2738,6 +2738,12 @@
                         "text": "Name",
                         "context": "brief"
                      }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 105
+                     }
                   ]
                },
                "provenance_source": {
@@ -2886,7 +2892,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 105
+                                 "priority_order": 110
                               }
                            ]
                         },
@@ -2911,7 +2917,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 110
+                                 "priority_order": 115
                               }
                            ]
                         }
@@ -3884,7 +3890,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 115
+                        "priority_order": 120
                      }
                   ]
                },
@@ -3911,7 +3917,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 120
+                        "priority_order": 125
                      }
                   ]
                },

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -7512,7 +7512,8 @@
             ]
          },
          "minItems": 1,
-         "uniqueItems": true
+         "uniqueItems": true,
+         "rcsb_nested_indexing": true
       },
       "pdbx_molecule_features": {
          "type": "array",

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -2738,6 +2738,12 @@
                         "text": "Name",
                         "context": "brief"
                      }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 105
+                     }
                   ]
                },
                "provenance_source": {
@@ -2886,7 +2892,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 105
+                                 "priority_order": 110
                               }
                            ]
                         },
@@ -2911,7 +2917,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 110
+                                 "priority_order": 115
                               }
                            ]
                         }
@@ -3884,7 +3890,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 115
+                        "priority_order": 120
                      }
                   ]
                },
@@ -3911,7 +3917,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 120
+                        "priority_order": 125
                      }
                   ]
                },


### PR DESCRIPTION
This PR addresses RO-3904 and RO-4002. Updated schemas to
 - add UI metadata for Pfam protein family name
 - improve indexing for pdbx_initial_refinement_model

