### PR TITLE
RO-4015: Remove GO and InterPro context values

### DIFF
--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -143,6 +143,7 @@
 # 26-Jul-2023   bv RO-3904: Add UI metadata for Pfam protein family name
 #                  RO-4002: Improve indexing for pdbx_initial_refinement_model
 # 26-Jul-2023   bv RO-3979: Add support for reference sequence and entity sequence coverage information for polymer entities
+# 08-Aug-2023  dwp RO-4015: Remove GO and InterPro context values from rcsb_nested_indexing_context.context_attributes in pdbx_core_polymer_entity
 # 
 ---
 database_catalog_configuration:
@@ -1685,7 +1686,7 @@ document_helper_configuration:
       - NAME: pdbx_comp_model_core_assembly
         VERSION: 1.0.0
       - NAME: pdbx_comp_model_core_polymer_entity
-        VERSION: 1.0.2
+        VERSION: 1.0.3
       - NAME: pdbx_comp_model_core_nonpolymer_entity
         VERSION: 1.0.0
       - NAME: pdbx_comp_model_core_branched_entity
@@ -1713,7 +1714,7 @@ document_helper_configuration:
       - NAME: pdbx_core_assembly
         VERSION: 9.0.0
       - NAME: pdbx_core_polymer_entity
-        VERSION: 10.0.2
+        VERSION: 10.0.3
       - NAME: pdbx_core_nonpolymer_entity
         VERSION: 10.0.0
       - NAME: pdbx_core_branched_entity
@@ -3986,32 +3987,6 @@ document_helper_configuration:
         CONTEXT_ATTRIBUTE_NAMES:
           - rcsb_polymer_entity_annotation.type
         CONTEXT_ATTRIBUTE_VALUES:
-          - CONTEXT_VALUE: GO
-            SEARCH_PATHS:
-              - rcsb_polymer_entity_annotation.annotation_lineage.id
-              - rcsb_polymer_entity_annotation.annotation_lineage.name
-            ATTRIBUTES:
-              - PATH: rcsb_polymer_entity_annotation.annotation_lineage.id
-                EXAMPLES:
-                  - "GO:0005575"
-                  - "GO:0005622"
-              - PATH: rcsb_polymer_entity_annotation.annotation_lineage.name
-                EXAMPLES:
-                  - "cellular_component"
-                  - "intracellular"
-          - CONTEXT_VALUE: InterPro
-            SEARCH_PATHS:
-              - rcsb_polymer_entity_annotation.annotation_id
-              - rcsb_polymer_entity_annotation.name
-            ATTRIBUTES:
-              - PATH: rcsb_polymer_entity_annotation.annotation_id
-                EXAMPLES:
-                  - IPR022352
-                  - IPR004825
-              - PATH: rcsb_polymer_entity_annotation.name
-                EXAMPLES:
-                  - "Insulin family"
-                  - Insulin
           - CONTEXT_VALUE: Pfam
             SEARCH_PATHS:
               - rcsb_polymer_entity_annotation.annotation_id

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
@@ -3025,44 +3025,6 @@
                "category_path": "rcsb_polymer_entity_annotation.type",
                "context_attributes": [
                   {
-                     "context_value": "GO",
-                     "attributes": [
-                        {
-                           "examples": [
-                              "GO:0005575",
-                              "GO:0005622"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_lineage.id"
-                        },
-                        {
-                           "examples": [
-                              "cellular_component",
-                              "intracellular"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_lineage.name"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "InterPro",
-                     "attributes": [
-                        {
-                           "examples": [
-                              "IPR022352",
-                              "IPR004825"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_id"
-                        },
-                        {
-                           "examples": [
-                              "Insulin family",
-                              "Insulin"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.name"
-                        }
-                     ]
-                  },
-                  {
                      "context_value": "Pfam",
                      "attributes": [
                         {
@@ -4767,7 +4729,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_polymer_entity.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_polymer_entity version: 1.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_polymer_entity version 1.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_polymer_entity.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 1.0.2"
+   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_polymer_entity version: 1.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_polymer_entity version 1.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_polymer_entity.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 1.0.3"
 }

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -3025,44 +3025,6 @@
                "category_path": "rcsb_polymer_entity_annotation.type",
                "context_attributes": [
                   {
-                     "context_value": "GO",
-                     "attributes": [
-                        {
-                           "examples": [
-                              "GO:0005575",
-                              "GO:0005622"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_lineage.id"
-                        },
-                        {
-                           "examples": [
-                              "cellular_component",
-                              "intracellular"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_lineage.name"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "InterPro",
-                     "attributes": [
-                        {
-                           "examples": [
-                              "IPR022352",
-                              "IPR004825"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_id"
-                        },
-                        {
-                           "examples": [
-                              "Insulin family",
-                              "Insulin"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.name"
-                        }
-                     ]
-                  },
-                  {
                      "context_value": "Pfam",
                      "attributes": [
                         {
@@ -4767,7 +4729,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_polymer_entity.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity version: 10.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity version 10.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_polymer_entity.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 10.0.2"
+   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity version: 10.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity version 10.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_polymer_entity.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 10.0.3"
 }

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
@@ -3013,44 +3013,6 @@
                "category_path": "rcsb_polymer_entity_annotation.type",
                "context_attributes": [
                   {
-                     "context_value": "GO",
-                     "attributes": [
-                        {
-                           "examples": [
-                              "GO:0005575",
-                              "GO:0005622"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_lineage.id"
-                        },
-                        {
-                           "examples": [
-                              "cellular_component",
-                              "intracellular"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_lineage.name"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "InterPro",
-                     "attributes": [
-                        {
-                           "examples": [
-                              "IPR022352",
-                              "IPR004825"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_id"
-                        },
-                        {
-                           "examples": [
-                              "Insulin family",
-                              "Insulin"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.name"
-                        }
-                     ]
-                  },
-                  {
                      "context_value": "Pfam",
                      "attributes": [
                         {
@@ -4734,7 +4696,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_polymer_entity.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_polymer_entity version: 1.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_polymer_entity version 1.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_polymer_entity.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 1.0.2"
+   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_polymer_entity version: 1.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_polymer_entity version 1.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_polymer_entity.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 1.0.3"
 }

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -3013,44 +3013,6 @@
                "category_path": "rcsb_polymer_entity_annotation.type",
                "context_attributes": [
                   {
-                     "context_value": "GO",
-                     "attributes": [
-                        {
-                           "examples": [
-                              "GO:0005575",
-                              "GO:0005622"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_lineage.id"
-                        },
-                        {
-                           "examples": [
-                              "cellular_component",
-                              "intracellular"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_lineage.name"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "InterPro",
-                     "attributes": [
-                        {
-                           "examples": [
-                              "IPR022352",
-                              "IPR004825"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.annotation_id"
-                        },
-                        {
-                           "examples": [
-                              "Insulin family",
-                              "Insulin"
-                           ],
-                           "path": "rcsb_polymer_entity_annotation.name"
-                        }
-                     ]
-                  },
-                  {
                      "context_value": "Pfam",
                      "attributes": [
                         {
@@ -4734,7 +4696,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_polymer_entity.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity version: 10.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity version 10.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_polymer_entity.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 10.0.2"
+   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity version: 10.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity version 10.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_polymer_entity.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 10.0.3"
 }

--- a/schema_definitions/schema_def-pdbx_comp_model_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_comp_model_core-ANY.json
@@ -99868,7 +99868,7 @@
          },
          {
             "NAME": "pdbx_comp_model_core_polymer_entity",
-            "VERSION": "1.0.2"
+            "VERSION": "1.0.3"
          },
          {
             "NAME": "pdbx_comp_model_core_nonpolymer_entity",

--- a/schema_definitions/schema_def-pdbx_comp_model_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_comp_model_core-SQL.json
@@ -99868,7 +99868,7 @@
          },
          {
             "NAME": "pdbx_comp_model_core_polymer_entity",
-            "VERSION": "1.0.2"
+            "VERSION": "1.0.3"
          },
          {
             "NAME": "pdbx_comp_model_core_nonpolymer_entity",

--- a/schema_definitions/schema_def-pdbx_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_core-ANY.json
@@ -99868,7 +99868,7 @@
          },
          {
             "NAME": "pdbx_core_polymer_entity",
-            "VERSION": "10.0.2"
+            "VERSION": "10.0.3"
          },
          {
             "NAME": "pdbx_core_nonpolymer_entity",

--- a/schema_definitions/schema_def-pdbx_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_core-SQL.json
@@ -99868,7 +99868,7 @@
          },
          {
             "NAME": "pdbx_core_polymer_entity",
-            "VERSION": "10.0.2"
+            "VERSION": "10.0.3"
          },
          {
             "NAME": "pdbx_core_nonpolymer_entity",


### PR DESCRIPTION
[RO-4015](https://rcsbpdb.atlassian.net/browse/RO-4015): Remove GO and InterPro context values from `rcsb_nested_indexing_context.context_attributes` in `pdbx_core_polymer_entity`