### PR TITLE
Update mmcif_pdbx_v5_next.cif reference dictionary and regenerate schemas

### DIFF
--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -156,6 +156,7 @@
 # 30-Jul-2024  dwp RO-4209: Bump patch version for polymer_entity_instance types after extending rcsb_polymer_instance_feature.type enumerations for ligand interactions
 # 23-Aug-2024   bv RO-4361: Update label under rcsb_description for em_software.name
 # 09-Sep-2024  dwp RO-4377: Bump minor version for repository_holdings_current_entry
+# 22-Oct-2024  dwp Bump patch version for bird_chem_comp_core, pdbx_core_entry, pdbx_comp_model_core_entry
 ---
 database_catalog_configuration:
   #
@@ -1705,7 +1706,7 @@ document_helper_configuration:
   document_collection_names:
     pdbx_comp_model_core:
       - NAME: pdbx_comp_model_core_entry
-        VERSION: 1.0.3
+        VERSION: 1.0.4
       - NAME: pdbx_comp_model_core_assembly
         VERSION: 1.0.0
       - NAME: pdbx_comp_model_core_polymer_entity
@@ -1733,7 +1734,7 @@ document_helper_configuration:
         VERSION: 5.2.0
     pdbx_core:
       - NAME: pdbx_core_entry
-        VERSION: 9.0.2
+        VERSION: 9.0.3
       - NAME: pdbx_core_assembly
         VERSION: 9.0.0
       - NAME: pdbx_core_polymer_entity
@@ -1762,7 +1763,7 @@ document_helper_configuration:
         VERSION: 5.2.3
     bird_chem_comp_core:
       - NAME: bird_chem_comp_core
-        VERSION: 7.1.3
+        VERSION: 7.1.4
     pdb_distro: []
     repository_holdings:
       - NAME: repository_holdings_update_entry

--- a/dictionary_files/base/rcsb_mmcif_ext-header.dic
+++ b/dictionary_files/base/rcsb_mmcif_ext-header.dic
@@ -155,6 +155,7 @@
 #  26-Mar-2024  dwp  RO-3958: Add GlyGen to rcsb_polymer_instance_annotation.type enumeration list
 #  30-Jul-2024  dwp  RO-4209: Add new enumerations for ligand interaction features
 #  09-Sep-2024  dwp  RO-4377: Add new enumerations for repository_content_types
+#  22-Oct-2024  dwp  Update mmcif_pdbx_v5_next.dic to latest version (5.405)
 #
 ###########################################################################
 ###########################################################################

--- a/dictionary_files/base/rcsb_mmcif_ext-header.dic
+++ b/dictionary_files/base/rcsb_mmcif_ext-header.dic
@@ -155,7 +155,6 @@
 #  26-Mar-2024  dwp  RO-3958: Add GlyGen to rcsb_polymer_instance_annotation.type enumeration list
 #  30-Jul-2024  dwp  RO-4209: Add new enumerations for ligand interaction features
 #  09-Sep-2024  dwp  RO-4377: Add new enumerations for repository_content_types
-#  22-Oct-2024  dwp  Update mmcif_pdbx_v5_next.dic to latest version (5.405)
 #
 ###########################################################################
 ###########################################################################

--- a/json_schema_definitions/bson-full-db-bird_chem_comp_core-col-bird_chem_comp_core.json
+++ b/json_schema_definitions/bson-full-db-bird_chem_comp_core-col-bird_chem_comp_core.json
@@ -122,6 +122,7 @@
                   "enum": [
                      "Create component",
                      "Initial release",
+                     "Modify PCM",
                      "Modify aromatic_flag",
                      "Modify atom id",
                      "Modify backbone",

--- a/json_schema_definitions/bson-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/bson-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -1574,6 +1574,7 @@
                      "LEICA PLUNGER",
                      "REICHERT-JUNG PLUNGER",
                      "SPOTITON",
+                     "SPT LABTECH CHAMELEON",
                      "ZEISS PLUNGE FREEZER CRYOBOX"
                   ]
                },

--- a/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -1574,6 +1574,7 @@
                      "LEICA PLUNGER",
                      "REICHERT-JUNG PLUNGER",
                      "SPOTITON",
+                     "SPT LABTECH CHAMELEON",
                      "ZEISS PLUNGE FREEZER CRYOBOX"
                   ]
                },

--- a/json_schema_definitions/bson-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
+++ b/json_schema_definitions/bson-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
@@ -121,6 +121,7 @@
                   "enum": [
                      "Create component",
                      "Initial release",
+                     "Modify PCM",
                      "Modify aromatic_flag",
                      "Modify atom id",
                      "Modify backbone",

--- a/json_schema_definitions/bson-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/bson-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -1394,6 +1394,7 @@
                      "LEICA PLUNGER",
                      "REICHERT-JUNG PLUNGER",
                      "SPOTITON",
+                     "SPT LABTECH CHAMELEON",
                      "ZEISS PLUNGE FREEZER CRYOBOX"
                   ]
                },

--- a/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -1394,6 +1394,7 @@
                      "LEICA PLUNGER",
                      "REICHERT-JUNG PLUNGER",
                      "SPOTITON",
+                     "SPT LABTECH CHAMELEON",
                      "ZEISS PLUNGE FREEZER CRYOBOX"
                   ]
                },

--- a/json_schema_definitions/json-full-db-bird_chem_comp_core-col-bird_chem_comp_core.json
+++ b/json_schema_definitions/json-full-db-bird_chem_comp_core-col-bird_chem_comp_core.json
@@ -4466,7 +4466,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-bird_chem_comp_core.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: bird_chem_comp_core collection: bird_chem_comp_core version: 7.1.3",
-   "description": "RCSB Exchange Database JSON schema derived from the bird_chem_comp_core content type schema. This schema supports collection bird_chem_comp_core version 7.1.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-bird_chem_comp_core.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 7.1.3"
+   "title": "schema: bird_chem_comp_core collection: bird_chem_comp_core version: 7.1.4",
+   "description": "RCSB Exchange Database JSON schema derived from the bird_chem_comp_core content type schema. This schema supports collection bird_chem_comp_core version 7.1.4. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-bird_chem_comp_core.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 7.1.4"
 }

--- a/json_schema_definitions/json-full-db-bird_chem_comp_core-col-bird_chem_comp_core.json
+++ b/json_schema_definitions/json-full-db-bird_chem_comp_core-col-bird_chem_comp_core.json
@@ -505,6 +505,7 @@
                   "enum": [
                      "Create component",
                      "Initial release",
+                     "Modify PCM",
                      "Modify aromatic_flag",
                      "Modify atom id",
                      "Modify backbone",

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -4588,6 +4588,7 @@
                      "LEICA PLUNGER",
                      "REICHERT-JUNG PLUNGER",
                      "SPOTITON",
+                     "SPT LABTECH CHAMELEON",
                      "ZEISS PLUNGE FREEZER CRYOBOX"
                   ],
                   "description": "The type of instrument used in the vitrification process.",
@@ -7226,7 +7227,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7297,7 +7298,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor"
+                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor"
                ],
                "description": "Code for status of chemical shift data file.",
                "rcsb_enum_annotated": [
@@ -7319,7 +7320,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7374,7 +7375,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of NMR constraints file.",
                "rcsb_enum_annotated": [
@@ -7396,7 +7397,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7450,7 +7451,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of structure factor file.",
                "rcsb_enum_annotated": [
@@ -7468,7 +7469,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -9071,10 +9072,14 @@
                      "AVANCE III HD",
                      "WH",
                      "WM",
+                     "AC+",
+                     "Alpha",
                      "AM",
                      "AMX",
+                     "AMX II",
                      "DMX",
                      "DRX",
+                     "DSX",
                      "MSL",
                      "OMEGA",
                      "OMEGA PSG",
@@ -9086,10 +9091,15 @@
                      "EX",
                      "LA",
                      "ECP",
-                     "VXRS",
+                     "Infinityplus",
+                     "Mercury",
+                     "VNMRS",
+                     "VXR",
                      "UNITY",
+                     "UNITY INOVA",
                      "UNITYPLUS",
-                     "INOVA"
+                     "INOVA",
+                     "home-built"
                   ],
                   "description": "The model of the NMR spectrometer.",
                   "rcsb_search_context": [

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -16140,7 +16140,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_entry version: 1.0.3",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_entry version 1.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 1.0.3"
+   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_entry version: 1.0.4",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_entry version 1.0.4. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 1.0.4"
 }

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -4588,6 +4588,7 @@
                      "LEICA PLUNGER",
                      "REICHERT-JUNG PLUNGER",
                      "SPOTITON",
+                     "SPT LABTECH CHAMELEON",
                      "ZEISS PLUNGE FREEZER CRYOBOX"
                   ],
                   "description": "The type of instrument used in the vitrification process.",
@@ -7226,7 +7227,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7297,7 +7298,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor"
+                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor"
                ],
                "description": "Code for status of chemical shift data file.",
                "rcsb_enum_annotated": [
@@ -7319,7 +7320,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7374,7 +7375,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of NMR constraints file.",
                "rcsb_enum_annotated": [
@@ -7396,7 +7397,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7450,7 +7451,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of structure factor file.",
                "rcsb_enum_annotated": [
@@ -7468,7 +7469,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -9071,10 +9072,14 @@
                      "AVANCE III HD",
                      "WH",
                      "WM",
+                     "AC+",
+                     "Alpha",
                      "AM",
                      "AMX",
+                     "AMX II",
                      "DMX",
                      "DRX",
+                     "DSX",
                      "MSL",
                      "OMEGA",
                      "OMEGA PSG",
@@ -9086,10 +9091,15 @@
                      "EX",
                      "LA",
                      "ECP",
-                     "VXRS",
+                     "Infinityplus",
+                     "Mercury",
+                     "VNMRS",
+                     "VXR",
                      "UNITY",
+                     "UNITY INOVA",
                      "UNITYPLUS",
-                     "INOVA"
+                     "INOVA",
+                     "home-built"
                   ],
                   "description": "The model of the NMR spectrometer.",
                   "rcsb_search_context": [

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -16140,7 +16140,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 9.0.2"
+   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 9.0.3"
 }

--- a/json_schema_definitions/json-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
+++ b/json_schema_definitions/json-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
@@ -4428,7 +4428,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-bird_chem_comp_core.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: bird_chem_comp_core collection: bird_chem_comp_core version: 7.1.3",
-   "description": "RCSB Exchange Database JSON schema derived from the bird_chem_comp_core content type schema. This schema supports collection bird_chem_comp_core version 7.1.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-bird_chem_comp_core.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 7.1.3"
+   "title": "schema: bird_chem_comp_core collection: bird_chem_comp_core version: 7.1.4",
+   "description": "RCSB Exchange Database JSON schema derived from the bird_chem_comp_core content type schema. This schema supports collection bird_chem_comp_core version 7.1.4. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-bird_chem_comp_core.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 7.1.4"
 }

--- a/json_schema_definitions/json-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
+++ b/json_schema_definitions/json-min-db-bird_chem_comp_core-col-bird_chem_comp_core.json
@@ -504,6 +504,7 @@
                   "enum": [
                      "Create component",
                      "Initial release",
+                     "Modify PCM",
                      "Modify aromatic_flag",
                      "Modify atom id",
                      "Modify backbone",

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -4408,6 +4408,7 @@
                      "LEICA PLUNGER",
                      "REICHERT-JUNG PLUNGER",
                      "SPOTITON",
+                     "SPT LABTECH CHAMELEON",
                      "ZEISS PLUNGE FREEZER CRYOBOX"
                   ],
                   "description": "The type of instrument used in the vitrification process.",
@@ -7023,7 +7024,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7094,7 +7095,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor"
+                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor"
                ],
                "description": "Code for status of chemical shift data file.",
                "rcsb_enum_annotated": [
@@ -7116,7 +7117,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7171,7 +7172,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of NMR constraints file.",
                "rcsb_enum_annotated": [
@@ -7193,7 +7194,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7247,7 +7248,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of structure factor file.",
                "rcsb_enum_annotated": [
@@ -7265,7 +7266,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -8856,10 +8857,14 @@
                      "AVANCE III HD",
                      "WH",
                      "WM",
+                     "AC+",
+                     "Alpha",
                      "AM",
                      "AMX",
+                     "AMX II",
                      "DMX",
                      "DRX",
+                     "DSX",
                      "MSL",
                      "OMEGA",
                      "OMEGA PSG",
@@ -8871,10 +8876,15 @@
                      "EX",
                      "LA",
                      "ECP",
-                     "VXRS",
+                     "Infinityplus",
+                     "Mercury",
+                     "VNMRS",
+                     "VXR",
                      "UNITY",
+                     "UNITY INOVA",
                      "UNITYPLUS",
-                     "INOVA"
+                     "INOVA",
+                     "home-built"
                   ],
                   "description": "The model of the NMR spectrometer.",
                   "rcsb_search_context": [

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -15738,7 +15738,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_entry version: 1.0.3",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_entry version 1.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 1.0.3"
+   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_entry version: 1.0.4",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_entry version 1.0.4. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 1.0.4"
 }

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -15738,7 +15738,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 9.0.2"
+   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 9.0.3"
 }

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -4408,6 +4408,7 @@
                      "LEICA PLUNGER",
                      "REICHERT-JUNG PLUNGER",
                      "SPOTITON",
+                     "SPT LABTECH CHAMELEON",
                      "ZEISS PLUNGE FREEZER CRYOBOX"
                   ],
                   "description": "The type of instrument used in the vitrification process.",
@@ -7023,7 +7024,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7094,7 +7095,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor"
+                  "PROC  = Processing in progress\n     WAIT  = Awaiting author approval\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor"
                ],
                "description": "Code for status of chemical shift data file.",
                "rcsb_enum_annotated": [
@@ -7116,7 +7117,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7171,7 +7172,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Release\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of NMR constraints file.",
                "rcsb_enum_annotated": [
@@ -7193,7 +7194,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -7247,7 +7248,7 @@
                   "WDRN"
                ],
                "examples": [
-                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted and replaced by another entry\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
+                  "PROC  = To be processed\n     REL   = Released\n     HOLD  = On hold until yyyy-mm-dd\n     HPUB  = On hold until publication\n     OBS   = Entry has been obsoleted\n     WDRN  = Entry has been withdrawn by depositor\n     WAIT  = Awaiting author approval"
                ],
                "description": "Code for status of structure factor file.",
                "rcsb_enum_annotated": [
@@ -7265,7 +7266,7 @@
                   },
                   {
                      "value": "OBS",
-                     "detail": "Entry has been obsoleted and replaced by another entry"
+                     "detail": "Entry has been obsoleted"
                   },
                   {
                      "value": "POLC",
@@ -8856,10 +8857,14 @@
                      "AVANCE III HD",
                      "WH",
                      "WM",
+                     "AC+",
+                     "Alpha",
                      "AM",
                      "AMX",
+                     "AMX II",
                      "DMX",
                      "DRX",
+                     "DSX",
                      "MSL",
                      "OMEGA",
                      "OMEGA PSG",
@@ -8871,10 +8876,15 @@
                      "EX",
                      "LA",
                      "ECP",
-                     "VXRS",
+                     "Infinityplus",
+                     "Mercury",
+                     "VNMRS",
+                     "VXR",
                      "UNITY",
+                     "UNITY INOVA",
                      "UNITYPLUS",
-                     "INOVA"
+                     "INOVA",
+                     "home-built"
                   ],
                   "description": "The model of the NMR spectrometer.",
                   "rcsb_search_context": [

--- a/schema_definitions/schema_def-bird_chem_comp_core-ANY.json
+++ b/schema_definitions/schema_def-bird_chem_comp_core-ANY.json
@@ -1322,6 +1322,7 @@
                "ENUMERATION": [
                   "Create component",
                   "Initial release",
+                  "Modify PCM",
                   "Modify aromatic_flag",
                   "Modify atom id",
                   "Modify backbone",

--- a/schema_definitions/schema_def-bird_chem_comp_core-ANY.json
+++ b/schema_definitions/schema_def-bird_chem_comp_core-ANY.json
@@ -7347,7 +7347,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "bird_chem_comp_core",
-            "VERSION": "7.1.3"
+            "VERSION": "7.1.4"
          }
       ],
       "COLLECTION_DOCUMENT_ATTRIBUTE_NAMES": {

--- a/schema_definitions/schema_def-bird_chem_comp_core-SQL.json
+++ b/schema_definitions/schema_def-bird_chem_comp_core-SQL.json
@@ -1322,6 +1322,7 @@
                "ENUMERATION": [
                   "Create component",
                   "Initial release",
+                  "Modify PCM",
                   "Modify aromatic_flag",
                   "Modify atom id",
                   "Modify backbone",

--- a/schema_definitions/schema_def-bird_chem_comp_core-SQL.json
+++ b/schema_definitions/schema_def-bird_chem_comp_core-SQL.json
@@ -7347,7 +7347,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "bird_chem_comp_core",
-            "VERSION": "7.1.3"
+            "VERSION": "7.1.4"
          }
       ],
       "COLLECTION_DOCUMENT_ATTRIBUTE_NAMES": {

--- a/schema_definitions/schema_def-pdbx_comp_model_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_comp_model_core-ANY.json
@@ -99945,7 +99945,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "pdbx_comp_model_core_entry",
-            "VERSION": "1.0.3"
+            "VERSION": "1.0.4"
          },
          {
             "NAME": "pdbx_comp_model_core_assembly",

--- a/schema_definitions/schema_def-pdbx_comp_model_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_comp_model_core-ANY.json
@@ -14216,6 +14216,7 @@
                   "LEICA PLUNGER",
                   "REICHERT-JUNG PLUNGER",
                   "SPOTITON",
+                  "SPT LABTECH CHAMELEON",
                   "ZEISS PLUNGE FREEZER CRYOBOX"
                ],
                "CONTENT_CLASSES": [],

--- a/schema_definitions/schema_def-pdbx_comp_model_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_comp_model_core-SQL.json
@@ -99945,7 +99945,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "pdbx_comp_model_core_entry",
-            "VERSION": "1.0.3"
+            "VERSION": "1.0.4"
          },
          {
             "NAME": "pdbx_comp_model_core_assembly",

--- a/schema_definitions/schema_def-pdbx_comp_model_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_comp_model_core-SQL.json
@@ -14216,6 +14216,7 @@
                   "LEICA PLUNGER",
                   "REICHERT-JUNG PLUNGER",
                   "SPOTITON",
+                  "SPT LABTECH CHAMELEON",
                   "ZEISS PLUNGE FREEZER CRYOBOX"
                ],
                "CONTENT_CLASSES": [],

--- a/schema_definitions/schema_def-pdbx_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_core-ANY.json
@@ -14216,6 +14216,7 @@
                   "LEICA PLUNGER",
                   "REICHERT-JUNG PLUNGER",
                   "SPOTITON",
+                  "SPT LABTECH CHAMELEON",
                   "ZEISS PLUNGE FREEZER CRYOBOX"
                ],
                "CONTENT_CLASSES": [],

--- a/schema_definitions/schema_def-pdbx_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_core-ANY.json
@@ -99945,7 +99945,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "pdbx_core_entry",
-            "VERSION": "9.0.2"
+            "VERSION": "9.0.3"
          },
          {
             "NAME": "pdbx_core_assembly",

--- a/schema_definitions/schema_def-pdbx_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_core-SQL.json
@@ -14216,6 +14216,7 @@
                   "LEICA PLUNGER",
                   "REICHERT-JUNG PLUNGER",
                   "SPOTITON",
+                  "SPT LABTECH CHAMELEON",
                   "ZEISS PLUNGE FREEZER CRYOBOX"
                ],
                "CONTENT_CLASSES": [],

--- a/schema_definitions/schema_def-pdbx_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_core-SQL.json
@@ -99945,7 +99945,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "pdbx_core_entry",
-            "VERSION": "9.0.2"
+            "VERSION": "9.0.3"
          },
          {
             "NAME": "pdbx_core_assembly",


### PR DESCRIPTION
Updated `mmcif_pdbx_v5_next.dic` to latest version (5.405) and regenerated schemas, to resolve recent loading issues for `bird_chem_comp_core` data (new data enumerations added).