### PR TITLE
Suppress `_em_particle_selection.num_particles_selected`

### DIFF
--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -157,6 +157,7 @@
 # 23-Aug-2024   bv RO-4361: Update label under rcsb_description for em_software.name
 # 09-Sep-2024  dwp RO-4377: Bump minor version for repository_holdings_current_entry
 # 23-Oct-2024   bv RO-4372 & RO-4392: Add/update search context for chem_comp.name and diffrn.pdbx_serial_crystal_experiment
+# 20-Dec-2024   bv PDB entry 8UVD fails JSON schema validation because of int64 value in _em_particle_selection.num_particles_selected (now suppressed in ExDB only)
 #
 ---
 database_catalog_configuration:
@@ -2758,6 +2759,10 @@ document_helper_configuration:
       - CATEGORY_NAME: em_imaging
         ATTRIBUTE_NAME_LIST:
           - entry_id
+      # Temporary fix to load 8UVD with int64 value
+      - CATEGORY_NAME: em_particle_selection
+        ATTRIBUTE_NAME_LIST:
+          - num_particles_selected
       - CATEGORY_NAME: em_single_particle_entity
         ATTRIBUTE_NAME_LIST:
           - entry_id

--- a/json_schema_definitions/bson-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/bson-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -1326,9 +1326,6 @@
                },
                "image_processing_id": {
                   "bsonType": "string"
-               },
-               "num_particles_selected": {
-                  "bsonType": "int"
                }
             },
             "additionalProperties": false,

--- a/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/bson-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -1326,9 +1326,6 @@
                },
                "image_processing_id": {
                   "bsonType": "string"
-               },
-               "num_particles_selected": {
-                  "bsonType": "int"
                }
             },
             "additionalProperties": false,

--- a/json_schema_definitions/bson-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/bson-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -1159,9 +1159,6 @@
                },
                "image_processing_id": {
                   "bsonType": "string"
-               },
-               "num_particles_selected": {
-                  "bsonType": "int"
                }
             },
             "additionalProperties": false,

--- a/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/bson-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -1159,9 +1159,6 @@
                },
                "image_processing_id": {
                   "bsonType": "string"
-               },
-               "num_particles_selected": {
-                  "bsonType": "int"
                }
             },
             "additionalProperties": false,

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -4010,19 +4010,6 @@
                         "context": "dictionary"
                      }
                   ]
-               },
-               "num_particles_selected": {
-                  "type": "integer",
-                  "description": "The number of particles selected from the projection set of images.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
-                  "rcsb_description": [
-                     {
-                        "text": "The number of particles selected from the projection set of images.",
-                        "context": "dictionary"
-                     }
-                  ]
                }
             },
             "additionalProperties": false,

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -4010,19 +4010,6 @@
                         "context": "dictionary"
                      }
                   ]
-               },
-               "num_particles_selected": {
-                  "type": "integer",
-                  "description": "The number of particles selected from the projection set of images.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
-                  "rcsb_description": [
-                     {
-                        "text": "The number of particles selected from the projection set of images.",
-                        "context": "dictionary"
-                     }
-                  ]
                }
             },
             "additionalProperties": false,

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -3843,19 +3843,6 @@
                         "context": "dictionary"
                      }
                   ]
-               },
-               "num_particles_selected": {
-                  "type": "integer",
-                  "description": "The number of particles selected from the projection set of images.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
-                  "rcsb_description": [
-                     {
-                        "text": "The number of particles selected from the projection set of images.",
-                        "context": "dictionary"
-                     }
-                  ]
                }
             },
             "additionalProperties": false,

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -3843,19 +3843,6 @@
                         "context": "dictionary"
                      }
                   ]
-               },
-               "num_particles_selected": {
-                  "type": "integer",
-                  "description": "The number of particles selected from the projection set of images.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
-                  "rcsb_description": [
-                     {
-                        "text": "The number of particles selected from the projection set of images.",
-                        "context": "dictionary"
-                     }
-                  ]
                }
             },
             "additionalProperties": false,

--- a/schema_definitions/schema_def-pdbx_comp_model_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_comp_model_core-ANY.json
@@ -100546,6 +100546,9 @@
                "em_imaging": [
                   "entry_id"
                ],
+               "em_particle_selection": [
+                  "num_particles_selected"
+               ],
                "em_single_particle_entity": [
                   "entry_id"
                ],

--- a/schema_definitions/schema_def-pdbx_comp_model_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_comp_model_core-SQL.json
@@ -100546,6 +100546,9 @@
                "em_imaging": [
                   "entry_id"
                ],
+               "em_particle_selection": [
+                  "num_particles_selected"
+               ],
                "em_single_particle_entity": [
                   "entry_id"
                ],

--- a/schema_definitions/schema_def-pdbx_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_core-ANY.json
@@ -100546,6 +100546,9 @@
                "em_imaging": [
                   "entry_id"
                ],
+               "em_particle_selection": [
+                  "num_particles_selected"
+               ],
                "em_single_particle_entity": [
                   "entry_id"
                ],

--- a/schema_definitions/schema_def-pdbx_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_core-SQL.json
@@ -100546,6 +100546,9 @@
                "em_imaging": [
                   "entry_id"
                ],
+               "em_particle_selection": [
+                  "num_particles_selected"
+               ],
                "em_single_particle_entity": [
                   "entry_id"
                ],


### PR DESCRIPTION
PDB entry `8UVD` fails JSON schema validation because of a field value that exceeds Max Int32 (2147483647). 

`_em_particle_selection.num_particles_selected   121691333209` 

This PR provides a temporary fix is to suppress `_em_particle_selection.num_particles_selected` in ExDB only (schema and data). 

At this point ExDB and DW schemas have diverged. 
