### PR TITLE
Update search metadata for attributes in `rcsb_nonpolymer_instance_feature_summary`

### DIFF
--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -1717,7 +1717,7 @@ document_helper_configuration:
   document_collection_names:
     pdbx_comp_model_core:
       - NAME: pdbx_comp_model_core_entry
-        VERSION: 1.0.4
+        VERSION: 1.0.5
       - NAME: pdbx_comp_model_core_assembly
         VERSION: 1.0.0
       - NAME: pdbx_comp_model_core_polymer_entity
@@ -1727,9 +1727,9 @@ document_helper_configuration:
       - NAME: pdbx_comp_model_core_branched_entity
         VERSION: 1.0.0
       - NAME: pdbx_comp_model_core_polymer_entity_instance
-        VERSION: 1.0.2
+        VERSION: 1.0.3
       - NAME: pdbx_comp_model_core_nonpolymer_entity_instance
-        VERSION: 1.0.0
+        VERSION: 1.0.1
       - NAME: pdbx_comp_model_core_branched_entity_instance
         VERSION: 1.0.0
     ihm_dev:

--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -158,6 +158,9 @@
 # 09-Sep-2024  dwp RO-4377: Bump minor version for repository_holdings_current_entry
 # 23-Oct-2024   bv RO-4372 & RO-4392: Add/update search context for chem_comp.name and diffrn.pdbx_serial_crystal_experiment
 #  8-Jan-2025   bv RO-4432 and RO-3699: Add selected tables from public mmcif_pdbx_vrpt dictionary to RCSB.org schemas
+#  8-Jan-2025   bv Update schema versions for collections impacted by incorporation of validation report data from mmCIF files
+#                  (pdbx_core_entry, pdbx_core_polymer_entity_instance, and pdbx_core_nonpolymer_entity_instance)
+#                  RO-4525: Update search metadata for attributes in rcsb_nonpolymer_instance_feature_summary
 #
 ---
 database_catalog_configuration:
@@ -1742,7 +1745,7 @@ document_helper_configuration:
         VERSION: 5.2.0
     pdbx_core:
       - NAME: pdbx_core_entry
-        VERSION: 9.0.3
+        VERSION: 9.0.4
       - NAME: pdbx_core_assembly
         VERSION: 9.0.0
       - NAME: pdbx_core_polymer_entity
@@ -1752,9 +1755,9 @@ document_helper_configuration:
       - NAME: pdbx_core_branched_entity
         VERSION: 10.0.0
       - NAME: pdbx_core_polymer_entity_instance
-        VERSION: 10.0.2
+        VERSION: 10.0.3
       - NAME: pdbx_core_nonpolymer_entity_instance
-        VERSION: 10.0.0
+        VERSION: 10.0.1
       - NAME: pdbx_core_branched_entity_instance
         VERSION: 9.0.0
     bird:
@@ -4295,60 +4298,6 @@ document_helper_configuration:
                   - "F: Evr1_Alr"
                   - "F: Peptidase_C30_C"
     pdbx_core_nonpolymer_entity_instance: &ccn_pdbx_core_nonpolymer_entity_instance
-      - CATEGORY: rcsb_nonpolymer_instance_feature_summary
-        NAME: feature_summary
-        CONTEXT_ATTRIBUTE_NAMES:
-          - rcsb_nonpolymer_instance_feature_summary.type
-        CONTEXT_ATTRIBUTE_VALUES:
-          - CONTEXT_VALUE: HAS_COVALENT_LINKAGE
-            SEARCH_PATHS:
-              - rcsb_nonpolymer_instance_feature_summary.count
-            ATTRIBUTES:
-              - PATH: rcsb_nonpolymer_instance_feature_summary.count
-                EXAMPLES:
-                  - 1
-                  - 5
-          - CONTEXT_VALUE: HAS_METAL_COORDINATION_LINKAGE
-            SEARCH_PATHS:
-              - rcsb_nonpolymer_instance_feature_summary.count
-            ATTRIBUTES:
-              - PATH: rcsb_nonpolymer_instance_feature_summary.count
-                EXAMPLES:
-                  - 1
-                  - 5
-          - CONTEXT_VALUE: MOGUL_ANGLE_OUTLIER
-            SEARCH_PATHS:
-              - rcsb_nonpolymer_instance_feature_summary.count
-            ATTRIBUTES:
-              - PATH: rcsb_nonpolymer_instance_feature_summary.count
-                EXAMPLES:
-                  - 1
-                  - 5
-          - CONTEXT_VALUE: MOGUL_BOND_OUTLIER
-            SEARCH_PATHS:
-              - rcsb_nonpolymer_instance_feature_summary.count
-            ATTRIBUTES:
-              - PATH: rcsb_nonpolymer_instance_feature_summary.count
-                EXAMPLES:
-                  - 1
-                  - 5
-          - CONTEXT_VALUE: RSCC_OUTLIER
-            SEARCH_PATHS:
-              - rcsb_nonpolymer_instance_feature_summary.count
-            ATTRIBUTES:
-              - PATH: rcsb_nonpolymer_instance_feature_summary.count
-                EXAMPLES:
-                  - 1
-                  - 5
-          - CONTEXT_VALUE: RSRZ_OUTLIER
-            SEARCH_PATHS:
-              - rcsb_nonpolymer_instance_feature_summary.count
-            ATTRIBUTES:
-              - PATH: rcsb_nonpolymer_instance_feature_summary.count
-                EXAMPLES:
-                  - 1
-                  - 5
-      # ---
       - CATEGORY: rcsb_nonpolymer_instance_annotation
         NAME: annotation_type
         CONTEXT_ATTRIBUTE_NAMES:
@@ -5320,8 +5269,6 @@ document_helper_configuration:
           - rcsb_nonpolymer_entity_instance_container_identifiers.entity_id
           - rcsb_nonpolymer_entity_instance_container_identifiers.entry_id
           - rcsb_nonpolymer_entity_instance_container_identifiers.rcsb_id
-          - rcsb_nonpolymer_instance_feature_summary.type
-          - rcsb_nonpolymer_instance_feature_summary.comp_id
           - rcsb_nonpolymer_instance_annotation.annotation_id
           - rcsb_nonpolymer_instance_annotation.type
           - rcsb_nonpolymer_instance_annotation.comp_id
@@ -5337,7 +5284,6 @@ document_helper_configuration:
           - rcsb_target_neighbors.target_is_bound
       - SEARCH_TYPE: default-match
         ATTRIBUTE_NAMES:
-          - rcsb_nonpolymer_instance_feature_summary.count
           - rcsb_nonpolymer_instance_annotation.annotation_lineage_depth
           - rcsb_nonpolymer_instance_validation_score.mogul_angles_RMSZ
           - rcsb_nonpolymer_instance_validation_score.mogul_bonds_RMSZ
@@ -6849,13 +6795,6 @@ document_helper_configuration:
       TYPE: brief
       TEXT: Lineage Depth
     #
-    - ATTRIBUTE_NAME: rcsb_nonpolymer_instance_feature_summary.type
-      TYPE: brief
-      TEXT: Feature Type
-    - ATTRIBUTE_NAME: rcsb_nonpolymer_instance_feature_summary.count
-      TYPE: brief
-      TEXT: Feature Count
-    ##
     - ATTRIBUTE_NAME: rcsb_nonpolymer_instance_feature.annotation_id
       TYPE: brief
       TEXT: Identifier

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -17018,7 +17018,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_entry version: 1.0.4",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_entry version 1.0.4. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 1.0.4"
+   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_entry version: 1.0.5",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_entry version 1.0.5. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 1.0.5"
 }

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity_instance.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity_instance.json
@@ -958,10 +958,6 @@
                "comp_id": {
                   "type": "string",
                   "description": "Component identifier for non-polymer entity instance.",
-                  "rcsb_search_context": [
-                     "exact-match"
-                  ],
-                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "Component identifier for non-polymer entity instance.",
@@ -972,17 +968,10 @@
                "count": {
                   "type": "integer",
                   "description": "The feature count.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
                   "rcsb_description": [
                      {
                         "text": "The feature count.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Feature Count",
-                        "context": "brief"
                      }
                   ]
                },
@@ -1070,10 +1059,6 @@
                      "MOGUL_BOND_OUTLIER"
                   ],
                   "description": "Type or category of the feature.",
-                  "rcsb_search_context": [
-                     "exact-match"
-                  ],
-                  "rcsb_full_text_priority": 10,
                   "rcsb_enum_annotated": [
                      {
                         "value": "HAS_COVALENT_LINKAGE",
@@ -1132,10 +1117,6 @@
                      {
                         "text": "Type or category of the feature.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Feature Type",
-                        "context": "brief"
                      }
                   ]
                }
@@ -1147,88 +1128,7 @@
             ]
          },
          "minItems": 1,
-         "uniqueItems": true,
-         "rcsb_nested_indexing": true,
-         "rcsb_nested_indexing_context": [
-            {
-               "category_name": "feature_summary",
-               "category_path": "rcsb_nonpolymer_instance_feature_summary.type",
-               "context_attributes": [
-                  {
-                     "context_value": "HAS_COVALENT_LINKAGE",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "HAS_METAL_COORDINATION_LINKAGE",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "MOGUL_ANGLE_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "MOGUL_BOND_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "RSCC_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "RSRZ_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  }
-               ]
-            }
-         ]
+         "uniqueItems": true
       },
       "rcsb_nonpolymer_instance_validation_score": {
          "type": "array",
@@ -2297,7 +2197,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_nonpolymer_entity_instance.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_nonpolymer_entity_instance version: 1.0.0",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_nonpolymer_entity_instance version 1.0.0. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_nonpolymer_entity_instance.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 1.0.0"
+   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_nonpolymer_entity_instance version: 1.0.1",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_nonpolymer_entity_instance version 1.0.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_nonpolymer_entity_instance.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 1.0.1"
 }

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity_instance.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity_instance.json
@@ -2796,7 +2796,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_polymer_entity_instance.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_polymer_entity_instance version: 1.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_polymer_entity_instance version 1.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_polymer_entity_instance.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 1.0.2"
+   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_polymer_entity_instance version: 1.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_polymer_entity_instance version 1.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_comp_model_core_polymer_entity_instance.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 1.0.3"
 }

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -17018,7 +17018,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.3",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 9.0.3"
+   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.4",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.4. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 9.0.4"
 }

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_nonpolymer_entity_instance.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_nonpolymer_entity_instance.json
@@ -958,10 +958,6 @@
                "comp_id": {
                   "type": "string",
                   "description": "Component identifier for non-polymer entity instance.",
-                  "rcsb_search_context": [
-                     "exact-match"
-                  ],
-                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "Component identifier for non-polymer entity instance.",
@@ -972,17 +968,10 @@
                "count": {
                   "type": "integer",
                   "description": "The feature count.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
                   "rcsb_description": [
                      {
                         "text": "The feature count.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Feature Count",
-                        "context": "brief"
                      }
                   ]
                },
@@ -1070,10 +1059,6 @@
                      "MOGUL_BOND_OUTLIER"
                   ],
                   "description": "Type or category of the feature.",
-                  "rcsb_search_context": [
-                     "exact-match"
-                  ],
-                  "rcsb_full_text_priority": 10,
                   "rcsb_enum_annotated": [
                      {
                         "value": "HAS_COVALENT_LINKAGE",
@@ -1132,10 +1117,6 @@
                      {
                         "text": "Type or category of the feature.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Feature Type",
-                        "context": "brief"
                      }
                   ]
                }
@@ -1147,88 +1128,7 @@
             ]
          },
          "minItems": 1,
-         "uniqueItems": true,
-         "rcsb_nested_indexing": true,
-         "rcsb_nested_indexing_context": [
-            {
-               "category_name": "feature_summary",
-               "category_path": "rcsb_nonpolymer_instance_feature_summary.type",
-               "context_attributes": [
-                  {
-                     "context_value": "HAS_COVALENT_LINKAGE",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "HAS_METAL_COORDINATION_LINKAGE",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "MOGUL_ANGLE_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "MOGUL_BOND_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "RSCC_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "RSRZ_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  }
-               ]
-            }
-         ]
+         "uniqueItems": true
       },
       "rcsb_nonpolymer_instance_validation_score": {
          "type": "array",
@@ -2297,7 +2197,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_nonpolymer_entity_instance.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_nonpolymer_entity_instance version: 10.0.0",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_nonpolymer_entity_instance version 10.0.0. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_nonpolymer_entity_instance.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 10.0.0"
+   "title": "schema: pdbx_core collection: pdbx_core_nonpolymer_entity_instance version: 10.0.1",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_nonpolymer_entity_instance version 10.0.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_nonpolymer_entity_instance.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 10.0.1"
 }

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
@@ -2796,7 +2796,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_polymer_entity_instance.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity_instance version: 10.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity_instance version 10.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_polymer_entity_instance.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 10.0.2"
+   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity_instance version: 10.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity_instance version 10.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-full-pdbx_core_polymer_entity_instance.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 10.0.3"
 }

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -16593,7 +16593,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_entry version: 1.0.4",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_entry version 1.0.4. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 1.0.4"
+   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_entry version: 1.0.5",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_entry version 1.0.5. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 1.0.5"
 }

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity_instance.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity_instance.json
@@ -945,10 +945,6 @@
                "comp_id": {
                   "type": "string",
                   "description": "Component identifier for non-polymer entity instance.",
-                  "rcsb_search_context": [
-                     "exact-match"
-                  ],
-                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "Component identifier for non-polymer entity instance.",
@@ -959,17 +955,10 @@
                "count": {
                   "type": "integer",
                   "description": "The feature count.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
                   "rcsb_description": [
                      {
                         "text": "The feature count.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Feature Count",
-                        "context": "brief"
                      }
                   ]
                },
@@ -1057,10 +1046,6 @@
                      "MOGUL_BOND_OUTLIER"
                   ],
                   "description": "Type or category of the feature.",
-                  "rcsb_search_context": [
-                     "exact-match"
-                  ],
-                  "rcsb_full_text_priority": 10,
                   "rcsb_enum_annotated": [
                      {
                         "value": "HAS_COVALENT_LINKAGE",
@@ -1119,10 +1104,6 @@
                      {
                         "text": "Type or category of the feature.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Feature Type",
-                        "context": "brief"
                      }
                   ]
                }
@@ -1130,88 +1111,7 @@
             "additionalProperties": false
          },
          "minItems": 1,
-         "uniqueItems": true,
-         "rcsb_nested_indexing": true,
-         "rcsb_nested_indexing_context": [
-            {
-               "category_name": "feature_summary",
-               "category_path": "rcsb_nonpolymer_instance_feature_summary.type",
-               "context_attributes": [
-                  {
-                     "context_value": "HAS_COVALENT_LINKAGE",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "HAS_METAL_COORDINATION_LINKAGE",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "MOGUL_ANGLE_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "MOGUL_BOND_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "RSCC_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "RSRZ_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  }
-               ]
-            }
-         ]
+         "uniqueItems": true
       },
       "rcsb_nonpolymer_instance_validation_score": {
          "type": "array",
@@ -2264,7 +2164,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_nonpolymer_entity_instance.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_nonpolymer_entity_instance version: 1.0.0",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_nonpolymer_entity_instance version 1.0.0. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_nonpolymer_entity_instance.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 1.0.0"
+   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_nonpolymer_entity_instance version: 1.0.1",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_nonpolymer_entity_instance version 1.0.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_nonpolymer_entity_instance.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 1.0.1"
 }

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity_instance.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity_instance.json
@@ -2776,7 +2776,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_polymer_entity_instance.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_polymer_entity_instance version: 1.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_polymer_entity_instance version 1.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_polymer_entity_instance.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 1.0.2"
+   "title": "schema: pdbx_comp_model_core collection: pdbx_comp_model_core_polymer_entity_instance version: 1.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_comp_model_core content type schema. This schema supports collection pdbx_comp_model_core_polymer_entity_instance version 1.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_comp_model_core_polymer_entity_instance.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 1.0.3"
 }

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -16593,7 +16593,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.3",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 9.0.3"
+   "title": "schema: pdbx_core collection: pdbx_core_entry version: 9.0.4",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_entry version 9.0.4. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_entry.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 9.0.4"
 }

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_nonpolymer_entity_instance.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_nonpolymer_entity_instance.json
@@ -945,10 +945,6 @@
                "comp_id": {
                   "type": "string",
                   "description": "Component identifier for non-polymer entity instance.",
-                  "rcsb_search_context": [
-                     "exact-match"
-                  ],
-                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "Component identifier for non-polymer entity instance.",
@@ -959,17 +955,10 @@
                "count": {
                   "type": "integer",
                   "description": "The feature count.",
-                  "rcsb_search_context": [
-                     "default-match"
-                  ],
                   "rcsb_description": [
                      {
                         "text": "The feature count.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Feature Count",
-                        "context": "brief"
                      }
                   ]
                },
@@ -1057,10 +1046,6 @@
                      "MOGUL_BOND_OUTLIER"
                   ],
                   "description": "Type or category of the feature.",
-                  "rcsb_search_context": [
-                     "exact-match"
-                  ],
-                  "rcsb_full_text_priority": 10,
                   "rcsb_enum_annotated": [
                      {
                         "value": "HAS_COVALENT_LINKAGE",
@@ -1119,10 +1104,6 @@
                      {
                         "text": "Type or category of the feature.",
                         "context": "dictionary"
-                     },
-                     {
-                        "text": "Feature Type",
-                        "context": "brief"
                      }
                   ]
                }
@@ -1130,88 +1111,7 @@
             "additionalProperties": false
          },
          "minItems": 1,
-         "uniqueItems": true,
-         "rcsb_nested_indexing": true,
-         "rcsb_nested_indexing_context": [
-            {
-               "category_name": "feature_summary",
-               "category_path": "rcsb_nonpolymer_instance_feature_summary.type",
-               "context_attributes": [
-                  {
-                     "context_value": "HAS_COVALENT_LINKAGE",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "HAS_METAL_COORDINATION_LINKAGE",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "MOGUL_ANGLE_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "MOGUL_BOND_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "RSCC_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  },
-                  {
-                     "context_value": "RSRZ_OUTLIER",
-                     "attributes": [
-                        {
-                           "examples": [
-                              1,
-                              5
-                           ],
-                           "path": "rcsb_nonpolymer_instance_feature_summary.count"
-                        }
-                     ]
-                  }
-               ]
-            }
-         ]
+         "uniqueItems": true
       },
       "rcsb_nonpolymer_instance_validation_score": {
          "type": "array",
@@ -2264,7 +2164,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_nonpolymer_entity_instance.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_nonpolymer_entity_instance version: 10.0.0",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_nonpolymer_entity_instance version 10.0.0. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_nonpolymer_entity_instance.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 10.0.0"
+   "title": "schema: pdbx_core collection: pdbx_core_nonpolymer_entity_instance version: 10.0.1",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_nonpolymer_entity_instance version 10.0.1. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_nonpolymer_entity_instance.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 10.0.1"
 }

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
@@ -2776,7 +2776,7 @@
    ],
    "$id": "https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_polymer_entity_instance.json",
    "$schema": "http://json-schema.org/draft-04/schema#",
-   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity_instance version: 10.0.2",
-   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity_instance version 10.0.2. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_polymer_entity_instance.json and follows JSON schema specification version 4",
-   "$comment": "schema_version: 10.0.2"
+   "title": "schema: pdbx_core collection: pdbx_core_polymer_entity_instance version: 10.0.3",
+   "description": "RCSB Exchange Database JSON schema derived from the pdbx_core content type schema. This schema supports collection pdbx_core_polymer_entity_instance version 10.0.3. This schema is hosted in repository https://github.com/rcsb/py-rcsb.db/tree/master/rcsb.db/data/json-schema/json-schema-min-pdbx_core_polymer_entity_instance.json and follows JSON schema specification version 4",
+   "$comment": "schema_version: 10.0.3"
 }

--- a/schema_definitions/schema_def-pdbx_comp_model_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_comp_model_core-ANY.json
@@ -103354,7 +103354,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "pdbx_comp_model_core_entry",
-            "VERSION": "1.0.4"
+            "VERSION": "1.0.5"
          },
          {
             "NAME": "pdbx_comp_model_core_assembly",
@@ -103374,11 +103374,11 @@
          },
          {
             "NAME": "pdbx_comp_model_core_polymer_entity_instance",
-            "VERSION": "1.0.2"
+            "VERSION": "1.0.3"
          },
          {
             "NAME": "pdbx_comp_model_core_nonpolymer_entity_instance",
-            "VERSION": "1.0.0"
+            "VERSION": "1.0.1"
          },
          {
             "NAME": "pdbx_comp_model_core_branched_entity_instance",

--- a/schema_definitions/schema_def-pdbx_comp_model_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_comp_model_core-SQL.json
@@ -103354,7 +103354,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "pdbx_comp_model_core_entry",
-            "VERSION": "1.0.4"
+            "VERSION": "1.0.5"
          },
          {
             "NAME": "pdbx_comp_model_core_assembly",
@@ -103374,11 +103374,11 @@
          },
          {
             "NAME": "pdbx_comp_model_core_polymer_entity_instance",
-            "VERSION": "1.0.2"
+            "VERSION": "1.0.3"
          },
          {
             "NAME": "pdbx_comp_model_core_nonpolymer_entity_instance",
-            "VERSION": "1.0.0"
+            "VERSION": "1.0.1"
          },
          {
             "NAME": "pdbx_comp_model_core_branched_entity_instance",

--- a/schema_definitions/schema_def-pdbx_core-ANY.json
+++ b/schema_definitions/schema_def-pdbx_core-ANY.json
@@ -103354,7 +103354,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "pdbx_core_entry",
-            "VERSION": "9.0.3"
+            "VERSION": "9.0.4"
          },
          {
             "NAME": "pdbx_core_assembly",
@@ -103374,11 +103374,11 @@
          },
          {
             "NAME": "pdbx_core_polymer_entity_instance",
-            "VERSION": "10.0.2"
+            "VERSION": "10.0.3"
          },
          {
             "NAME": "pdbx_core_nonpolymer_entity_instance",
-            "VERSION": "10.0.0"
+            "VERSION": "10.0.1"
          },
          {
             "NAME": "pdbx_core_branched_entity_instance",

--- a/schema_definitions/schema_def-pdbx_core-SQL.json
+++ b/schema_definitions/schema_def-pdbx_core-SQL.json
@@ -103354,7 +103354,7 @@
       "CONTENT_TYPE_COLLECTION_INFO": [
          {
             "NAME": "pdbx_core_entry",
-            "VERSION": "9.0.3"
+            "VERSION": "9.0.4"
          },
          {
             "NAME": "pdbx_core_assembly",
@@ -103374,11 +103374,11 @@
          },
          {
             "NAME": "pdbx_core_polymer_entity_instance",
-            "VERSION": "10.0.2"
+            "VERSION": "10.0.3"
          },
          {
             "NAME": "pdbx_core_nonpolymer_entity_instance",
-            "VERSION": "10.0.0"
+            "VERSION": "10.0.1"
          },
          {
             "NAME": "pdbx_core_branched_entity_instance",


### PR DESCRIPTION
This PR
 - removes search metadata for attributes in `rcsb_nonpolymer_instance_feature_summary`, including `rcsb_nested_indexing` and `rcsb_nested_indexing_context`
 - updates version numbers for schemas updated in this PR and in https://github.com/rcsb/py-rcsb_exdb_assets/pull/148