### PR TITLE
Some new indexes from DW RO-4649

### DIFF
--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -3599,6 +3599,9 @@ document_helper_configuration:
       - INDEX_NAME: search_4
         ATTRIBUTE_NAMES:
           - rcsb_id
+      - INDEX_NAME: search_5
+        ATTRIBUTE_NAMES:
+          - pdbx_reference_molecule.prd_id
       #- INDEX_NAME: replace
       #  ATTRIBUTE_NAMES:
       #  - chem_comp.id

--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -3647,6 +3647,9 @@ document_helper_configuration:
       - INDEX_NAME: primary
         ATTRIBUTE_NAMES:
           - drugbank_info.drugbank_id
+      - INDEX_NAME: search_1
+        ATTRIBUTE_NAMES:
+          - drugbank_container_identifiers.drubbank_id
     uniprot_core:
       - INDEX_NAME: primary
         ATTRIBUTE_NAMES:

--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -3649,7 +3649,7 @@ document_helper_configuration:
           - drugbank_info.drugbank_id
       - INDEX_NAME: search_1
         ATTRIBUTE_NAMES:
-          - drugbank_container_identifiers.drubbank_id
+          - drugbank_container_identifiers.drugbank_id
     uniprot_core:
       - INDEX_NAME: primary
         ATTRIBUTE_NAMES:


### PR DESCRIPTION
These is all indexes I could find in DW settings that were not already in ExDB. 

One doubt: I see that `bird` collection [does define](https://github.com/rcsb/py-rcsb_exdb_assets/blob/89dc702c4bf85b1ca205f669215c3121f31f8272/config/exdb-config-schema.yml#L3573
) the index I'm defining in this PR, but I didn't see it in `bird_chem_comp_core`, that's why I added it. Is that ok?