### PR TITLE
Test DIAMOND sequence clustering DIAMOND provenance_info

### DIFF
--- a/provenance/rcsb_extend_provenance_info.json
+++ b/provenance/rcsb_extend_provenance_info.json
@@ -3,41 +3,52 @@
 "software": [
 {
 "pdbx_ordinal": 1,
-"name": "MMseq2",
-"version": "7d26617002d155353b375b47404621d4b07e196a",
-"date": "2017",
+"name": "DIAMOND",
+"version": "v2.1.13",
+"date": "2025",
 "type": "package",
-"contact_author": "Martin Steinegger",
-"contact_author_email": "martin.steinegger@mpibpc.mpg.de",
+"contact_author": "Benjamin Buchfink",
+"contact_author_email": "buchfink@gmail.com",
 "classification": "bioinformatics",
-"location": "https://github.com/soedinglab/MMseqs2",
+"location": "https://github.com/bbuchfink/diamond",
 "language": "C++",
-"citation_id": "mmseq2"
+"citation_id": "diamond"
 }
 ],
 "citation": [
 {
-"id": "mmseq2",
-"title": "MMseqs2 enables sensitive protein sequence searching for the analysis of massive data sets.",
-"journal_abbrev": "Nat Biotechnol.",
-"journal_volume": "35",
-"page_first": "1026",
-"page_last": "1028",
-"year": 2017,
-"pdbx_database_id_PubMed": 29035372,
-"pdbx_database_id_DOI": "10.1038/nbt.3988"
+"id": "diamond",
+"title": "Sensitive clustering of protein sequences at tree-of-life scale using DIAMOND DeepClust",
+"journal_abbrev": "bioRxiv",
+"year": 2023,
+"pdbx_database_id_DOI": "10.1101/2023.01.24.525373"
 }
 ],
 "citation_author": [
 {
-"citation_id": "mmseq2",
-"name": "Steinegger, M.",
+"citation_id": "diamond",
+"name": "Buchfink, B.",
 "ordinal": 1
 },
 {
-"citation_id": "mmseq2",
-"name": "Soding, J.",
+"citation_id": "diamond",
+"name": "Ashkenazy, H.",
 "ordinal": 2
+},
+{
+  "citation_id": "diamond",
+  "name": "Reuter, K.",
+  "ordinal": 3
+},
+{
+  "citation_id": "diamond",
+  "name": "Kennedy, J. A.",
+  "ordinal": 4
+},
+{
+  "citation_id": "diamond",
+  "name": "Drost, H. G.",
+  "ordinal": 5
 }
 ]
 }


### PR DESCRIPTION
This PR is for updating the collection `cluster_provenance` in `sequence_clusters` db. It is used when loading Diamond generated clusters data into the `sequence_clusters` db. 
