### PR TITLE
RO-4752-4761

### DIFF
--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -183,6 +183,8 @@
 # 19-Nov-2025   bv RO-4752: Add search metadata for pdbx_vrpt_summary_em.Q_score
 # 20-Nov-2025   bv RO-4761: Add search metadata for rcsb_nonpolymer_instance_validation_score.Q_score 
 #                           and pdbx_vrpt_summary_entity_fit_to_map.Q_score
+#  9-Dec-2025   bv RO:4752: Provide better naming for entry and polymer instance Q-scores
+#  9-Dec-2025   bv RO:4761: Provide better naming ligand Q-scores
 #
 ---
 database_catalog_configuration:
@@ -7140,7 +7142,7 @@ document_helper_configuration:
       TEXT: Reconstruction Resolution
     - ATTRIBUTE_NAME: pdbx_vrpt_summary_em.Q_score
       TYPE: brief
-      TEXT: Q Score
+      TEXT: Entry Average Q-Score
     - ATTRIBUTE_NAME: refine.B_iso_mean
       TYPE: brief
       TEXT: Average B Factor
@@ -7424,7 +7426,7 @@ document_helper_configuration:
       TEXT: Lineage Depth
     - ATTRIBUTE_NAME: pdbx_vrpt_summary_entity_fit_to_map.Q_score
       TYPE: brief
-      TEXT: Q Score
+      TEXT: Polymer Instance Average Q-Score
     #
     ##
     - ATTRIBUTE_NAME: rcsb_nonpolymer_instance_annotation.annotation_id
@@ -7787,7 +7789,7 @@ document_helper_configuration:
       TEXT: Real Space Correlation Coefficient
     - ATTRIBUTE_NAME: rcsb_nonpolymer_instance_validation_score.Q_score
       TYPE: brief
-      TEXT: Q Score
+      TEXT: Ligand Q-Score
     - ATTRIBUTE_NAME: rcsb_nonpolymer_instance_validation_score.intermolecular_clashes
       TYPE: brief
       TEXT: Number of Intermolecular Vlashes

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -11459,7 +11459,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Entry Average Q-Score",
                         "context": "brief"
                      }
                   ],

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity_instance.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity_instance.json
@@ -91,7 +91,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Polymer Instance Average Q-Score",
                         "context": "brief"
                      }
                   ],
@@ -1202,7 +1202,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Ligand Q-Score",
                         "context": "brief"
                      }
                   ],

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity_instance.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity_instance.json
@@ -94,7 +94,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Polymer Instance Average Q-Score",
                         "context": "brief"
                      }
                   ],

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_entry.json
@@ -11459,7 +11459,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Entry Average Q-Score",
                         "context": "brief"
                      }
                   ],

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_nonpolymer_entity_instance.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_nonpolymer_entity_instance.json
@@ -91,7 +91,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Polymer Instance Average Q-Score",
                         "context": "brief"
                      }
                   ],
@@ -1202,7 +1202,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Ligand Q-Score",
                         "context": "brief"
                      }
                   ],

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
@@ -94,7 +94,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Polymer Instance Average Q-Score",
                         "context": "brief"
                      }
                   ],

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_entry.json
@@ -11167,7 +11167,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Entry Average Q-Score",
                         "context": "brief"
                      }
                   ],

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity_instance.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity_instance.json
@@ -89,7 +89,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Polymer Instance Average Q-Score",
                         "context": "brief"
                      }
                   ],
@@ -1186,7 +1186,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Ligand Q-Score",
                         "context": "brief"
                      }
                   ],

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity_instance.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity_instance.json
@@ -92,7 +92,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Polymer Instance Average Q-Score",
                         "context": "brief"
                      }
                   ],

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_entry.json
@@ -11167,7 +11167,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Entry Average Q-Score",
                         "context": "brief"
                      }
                   ],

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_nonpolymer_entity_instance.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_nonpolymer_entity_instance.json
@@ -89,7 +89,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Polymer Instance Average Q-Score",
                         "context": "brief"
                      }
                   ],
@@ -1186,7 +1186,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Ligand Q-Score",
                         "context": "brief"
                      }
                   ],

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity_instance.json
@@ -92,7 +92,7 @@
                         "context": "dictionary"
                      },
                      {
-                        "text": "Q Score",
+                        "text": "Polymer Instance Average Q-Score",
                         "context": "brief"
                      }
                   ],


### PR DESCRIPTION
This PR addresses search metadata naming updates for entry, polymer instance, and ligand Q-Scores as described in RO-4752 and RO-4761. 