### PR TITLE
RO-4688 and RO-4904

### DIFF
--- a/config/exdb-config-schema.yml
+++ b/config/exdb-config-schema.yml
@@ -183,8 +183,11 @@
 # 19-Nov-2025   bv RO-4752: Add search metadata for pdbx_vrpt_summary_em.Q_score
 # 20-Nov-2025   bv RO-4761: Add search metadata for rcsb_nonpolymer_instance_validation_score.Q_score 
 #                           and pdbx_vrpt_summary_entity_fit_to_map.Q_score
-#  9-Dec-2025   bv RO:4752: Provide better naming for entry and polymer instance Q-scores
-#  9-Dec-2025   bv RO:4761: Provide better naming ligand Q-scores
+#  9-Dec-2025   bv RO-4752: Provide better naming for entry and polymer instance Q-scores
+#  9-Dec-2025   bv RO-4761: Provide better naming ligand Q-scores
+#  4-Feb-2025   bv RO-4688: Add search metadata for entity_src_gen.gene_src_strain
+#  4-Feb-2025   bv RO-4904: Add search UI metadata for rcsb_polymer_entity_container_identifiers.prd_id,
+#                           rcsb_nonpolymer_entity_container_identifiers.prd_id, and rcsb_branched_entity_container_identifiers.prd_id
 #
 ---
 database_catalog_configuration:
@@ -5702,6 +5705,7 @@ document_helper_configuration:
       - SEARCH_TYPE: exact-match
         ATTRIBUTE_NAMES:
           - entity_poly.rcsb_entity_polymer_type
+          - entity_src_gen.gene_src_strain
           - entity_src_gen.pdbx_gene_src_cell_line
           - rcsb_entity_host_organism.common_name
           - rcsb_entity_host_organism.ncbi_common_names
@@ -5779,6 +5783,7 @@ document_helper_configuration:
           - rcsb_membrane_lineage.depth
       - SEARCH_TYPE: full-text
         ATTRIBUTE_NAMES:
+          - entity_src_gen.gene_src_strain
           - entity_src_gen.gene_src_tissue
           - entity_src_gen.pdbx_description
           - entity_src_gen.pdbx_gene_src_atcc
@@ -6326,9 +6331,11 @@ document_helper_configuration:
         - rcsb_entity_source_organism.ncbi_scientific_name
         - rcsb_entity_source_organism.ncbi_parent_scientific_name
         - rcsb_entity_source_organism.source_type
+        - entity_src_gen.gene_src_strain
         #
         - rcsb_polymer_entity.rcsb_source_part_count
         - rcsb_polymer_entity.rcsb_source_taxonomy_count
+        - rcsb_polymer_entity_container_identifiers.prd_id
         #
         - rcsb_entity_host_organism.taxonomy_lineage_name
         - rcsb_entity_host_organism.taxonomy_lineage_id
@@ -6361,6 +6368,7 @@ document_helper_configuration:
         - pdbx_entity_branch_descriptor.descriptor
         - pdbx_entity_branch.rcsb_branched_component_count
         - rcsb_branched_entity_container_identifiers.chem_comp_monomers
+        - rcsb_branched_entity_container_identifiers.prd_id
 
     - GROUP_NAME: Nonpolymer Molecular Features
       ATTRIBUTE_NAMES:
@@ -6369,6 +6377,7 @@ document_helper_configuration:
         - rcsb_nonpolymer_instance_annotation.comp_id
         - rcsb_nonpolymer_instance_validation_score.Q_score
         - rcsb_binding_affinity.value
+        - rcsb_nonpolymer_entity_container_identifiers.prd_id
 
     - GROUP_NAME: Polymer Instance (Chain) Features
       ATTRIBUTE_NAMES:
@@ -7092,12 +7101,18 @@ document_helper_configuration:
     - ATTRIBUTE_NAME: rcsb_entity_source_organism.source_type
       TYPE: brief
       TEXT: Source Organism Type
+    - ATTRIBUTE_NAME: entity_src_gen.gene_src_strain
+      TYPE: brief
+      TEXT: Source Organism Strain
     - ATTRIBUTE_NAME: rcsb_entity_host_organism.ncbi_scientific_name
       TYPE: brief
       TEXT: Expression Organism
     - ATTRIBUTE_NAME: rcsb_entity_host_organism.ncbi_common_names
       TYPE: brief
       TEXT: Common Name of Expression Organism
+    - ATTRIBUTE_NAME: rcsb_polymer_entity_container_identifiers.prd_id
+      TYPE: brief
+      TEXT: Polymer BIRD ID
     - ATTRIBUTE_NAME: rcsb_enzyme.lineage_id
       TYPE: brief
       TEXT: Enzyme Classification Number
@@ -7367,6 +7382,12 @@ document_helper_configuration:
     - ATTRIBUTE_NAME: rcsb_chem_comp_target.name
       TYPE: brief
       TEXT: Drug Target Name
+    - ATTRIBUTE_NAME: rcsb_nonpolymer_entity_container_identifiers.prd_id
+      TYPE: brief
+      TEXT: Ligand BIRD ID
+    - ATTRIBUTE_NAME: rcsb_branched_entity_container_identifiers.prd_id
+      TYPE: brief
+      TEXT: Branched BIRD ID
 
     #
     - ATTRIBUTE_NAME: rcsb_polymer_entity_annotation.annotation_id

--- a/json_schema_definitions/json-full-db-pdbx-col-pdbx.json
+++ b/json_schema_definitions/json-full-db-pdbx-col-pdbx.json
@@ -8454,6 +8454,16 @@
                      {
                         "text": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Source Organism Strain",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 80
                      }
                   ]
                },

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_branched_entity.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_branched_entity.json
@@ -640,6 +640,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Branched BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Oligosaccharide/Branched Molecular Features",
+                     "priority_order": 35
                   }
                ]
             },

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity.json
@@ -536,6 +536,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Ligand BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Nonpolymer Molecular Features",
+                     "priority_order": 30
                   }
                ]
             },

--- a/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
+++ b/json_schema_definitions/json-full-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
@@ -420,10 +420,25 @@
                      "BMH 71-18"
                   ],
                   "description": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
+                  "rcsb_search_context": [
+                     "exact-match",
+                     "full-text"
+                  ],
+                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Source Organism Strain",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 80
                      }
                   ]
                },
@@ -1828,7 +1843,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 95
+                                 "priority_order": 105
                               }
                            ]
                         },
@@ -1858,7 +1873,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 90
+                                 "priority_order": 100
                               }
                            ]
                         }
@@ -2267,7 +2282,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 150
+                        "priority_order": 160
                      }
                   ]
                },
@@ -2551,7 +2566,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 80
+                     "priority_order": 85
                   }
                ]
             },
@@ -2574,7 +2589,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 85
+                     "priority_order": 90
                   }
                ]
             },
@@ -2653,7 +2668,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 100
+                              "priority_order": 110
                            }
                         ]
                      },
@@ -2681,7 +2696,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 105
+                              "priority_order": 115
                            }
                         ]
                      }
@@ -3029,7 +3044,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 110
+                        "priority_order": 120
                      }
                   ]
                },
@@ -3090,7 +3105,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 115
+                        "priority_order": 125
                      }
                   ]
                },
@@ -3240,7 +3255,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 120
+                                 "priority_order": 130
                               }
                            ]
                         },
@@ -3265,7 +3280,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 125
+                                 "priority_order": 135
                               }
                            ]
                         }
@@ -3593,6 +3608,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Polymer BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Polymer Molecular Features",
+                     "priority_order": 95
                   }
                ]
             },
@@ -3781,7 +3806,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 145
+                              "priority_order": 155
                            }
                         ]
                      },
@@ -3828,7 +3853,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 140
+                              "priority_order": 150
                            }
                         ]
                      }
@@ -4330,7 +4355,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 130
+                        "priority_order": 140
                      }
                   ]
                },
@@ -4357,7 +4382,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 135
+                        "priority_order": 145
                      }
                   ]
                },

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_branched_entity.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_branched_entity.json
@@ -640,6 +640,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Branched BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Oligosaccharide/Branched Molecular Features",
+                     "priority_order": 35
                   }
                ]
             },

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_nonpolymer_entity.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_nonpolymer_entity.json
@@ -536,6 +536,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Ligand BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Nonpolymer Molecular Features",
+                     "priority_order": 30
                   }
                ]
             },

--- a/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/json_schema_definitions/json-full-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -420,10 +420,25 @@
                      "BMH 71-18"
                   ],
                   "description": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
+                  "rcsb_search_context": [
+                     "exact-match",
+                     "full-text"
+                  ],
+                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Source Organism Strain",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 80
                      }
                   ]
                },
@@ -1828,7 +1843,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 95
+                                 "priority_order": 105
                               }
                            ]
                         },
@@ -1858,7 +1873,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 90
+                                 "priority_order": 100
                               }
                            ]
                         }
@@ -2267,7 +2282,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 150
+                        "priority_order": 160
                      }
                   ]
                },
@@ -2551,7 +2566,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 80
+                     "priority_order": 85
                   }
                ]
             },
@@ -2574,7 +2589,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 85
+                     "priority_order": 90
                   }
                ]
             },
@@ -2653,7 +2668,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 100
+                              "priority_order": 110
                            }
                         ]
                      },
@@ -2681,7 +2696,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 105
+                              "priority_order": 115
                            }
                         ]
                      }
@@ -3029,7 +3044,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 110
+                        "priority_order": 120
                      }
                   ]
                },
@@ -3090,7 +3105,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 115
+                        "priority_order": 125
                      }
                   ]
                },
@@ -3240,7 +3255,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 120
+                                 "priority_order": 130
                               }
                            ]
                         },
@@ -3265,7 +3280,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 125
+                                 "priority_order": 135
                               }
                            ]
                         }
@@ -3593,6 +3608,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Polymer BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Polymer Molecular Features",
+                     "priority_order": 95
                   }
                ]
             },
@@ -3781,7 +3806,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 145
+                              "priority_order": 155
                            }
                         ]
                      },
@@ -3828,7 +3853,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 140
+                              "priority_order": 150
                            }
                         ]
                      }
@@ -4330,7 +4355,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 130
+                        "priority_order": 140
                      }
                   ]
                },
@@ -4357,7 +4382,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 135
+                        "priority_order": 145
                      }
                   ]
                },

--- a/json_schema_definitions/json-min-db-pdbx-col-pdbx.json
+++ b/json_schema_definitions/json-min-db-pdbx-col-pdbx.json
@@ -8231,6 +8231,16 @@
                      {
                         "text": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Source Organism Strain",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 80
                      }
                   ]
                },

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_branched_entity.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_branched_entity.json
@@ -625,6 +625,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Branched BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Oligosaccharide/Branched Molecular Features",
+                     "priority_order": 35
                   }
                ]
             },

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_nonpolymer_entity.json
@@ -531,6 +531,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Ligand BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Nonpolymer Molecular Features",
+                     "priority_order": 30
                   }
                ]
             },

--- a/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
+++ b/json_schema_definitions/json-min-db-pdbx_comp_model_core-col-pdbx_comp_model_core_polymer_entity.json
@@ -420,10 +420,25 @@
                      "BMH 71-18"
                   ],
                   "description": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
+                  "rcsb_search_context": [
+                     "exact-match",
+                     "full-text"
+                  ],
+                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Source Organism Strain",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 80
                      }
                   ]
                },
@@ -1828,7 +1843,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 95
+                                 "priority_order": 105
                               }
                            ]
                         },
@@ -1858,7 +1873,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 90
+                                 "priority_order": 100
                               }
                            ]
                         }
@@ -2267,7 +2282,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 150
+                        "priority_order": 160
                      }
                   ]
                },
@@ -2549,7 +2564,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 80
+                     "priority_order": 85
                   }
                ]
             },
@@ -2572,7 +2587,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 85
+                     "priority_order": 90
                   }
                ]
             },
@@ -2651,7 +2666,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 100
+                              "priority_order": 110
                            }
                         ]
                      },
@@ -2679,7 +2694,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 105
+                              "priority_order": 115
                            }
                         ]
                      }
@@ -3022,7 +3037,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 110
+                        "priority_order": 120
                      }
                   ]
                },
@@ -3083,7 +3098,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 115
+                        "priority_order": 125
                      }
                   ]
                },
@@ -3233,7 +3248,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 120
+                                 "priority_order": 130
                               }
                            ]
                         },
@@ -3258,7 +3273,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 125
+                                 "priority_order": 135
                               }
                            ]
                         }
@@ -3584,6 +3599,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Polymer BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Polymer Molecular Features",
+                     "priority_order": 95
                   }
                ]
             },
@@ -3772,7 +3797,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 145
+                              "priority_order": 155
                            }
                         ]
                      },
@@ -3819,7 +3844,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 140
+                              "priority_order": 150
                            }
                         ]
                      }
@@ -4318,7 +4343,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 130
+                        "priority_order": 140
                      }
                   ]
                },
@@ -4345,7 +4370,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 135
+                        "priority_order": 145
                      }
                   ]
                },

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_branched_entity.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_branched_entity.json
@@ -625,6 +625,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Branched BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Oligosaccharide/Branched Molecular Features",
+                     "priority_order": 35
                   }
                ]
             },

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_nonpolymer_entity.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_nonpolymer_entity.json
@@ -531,6 +531,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Ligand BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Nonpolymer Molecular Features",
+                     "priority_order": 30
                   }
                ]
             },

--- a/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
+++ b/json_schema_definitions/json-min-db-pdbx_core-col-pdbx_core_polymer_entity.json
@@ -420,10 +420,25 @@
                      "BMH 71-18"
                   ],
                   "description": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
+                  "rcsb_search_context": [
+                     "exact-match",
+                     "full-text"
+                  ],
+                  "rcsb_full_text_priority": 10,
                   "rcsb_description": [
                      {
                         "text": "The strain of the natural organism from which the gene was\n obtained, if relevant.",
                         "context": "dictionary"
+                     },
+                     {
+                        "text": "Source Organism Strain",
+                        "context": "brief"
+                     }
+                  ],
+                  "rcsb_search_group": [
+                     {
+                        "group_name": "Polymer Molecular Features",
+                        "priority_order": 80
                      }
                   ]
                },
@@ -1828,7 +1843,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 95
+                                 "priority_order": 105
                               }
                            ]
                         },
@@ -1858,7 +1873,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 90
+                                 "priority_order": 100
                               }
                            ]
                         }
@@ -2267,7 +2282,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 150
+                        "priority_order": 160
                      }
                   ]
                },
@@ -2549,7 +2564,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 80
+                     "priority_order": 85
                   }
                ]
             },
@@ -2572,7 +2587,7 @@
                "rcsb_search_group": [
                   {
                      "group_name": "Polymer Molecular Features",
-                     "priority_order": 85
+                     "priority_order": 90
                   }
                ]
             },
@@ -2651,7 +2666,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 100
+                              "priority_order": 110
                            }
                         ]
                      },
@@ -2679,7 +2694,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 105
+                              "priority_order": 115
                            }
                         ]
                      }
@@ -3022,7 +3037,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 110
+                        "priority_order": 120
                      }
                   ]
                },
@@ -3083,7 +3098,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 115
+                        "priority_order": 125
                      }
                   ]
                },
@@ -3233,7 +3248,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 120
+                                 "priority_order": 130
                               }
                            ]
                         },
@@ -3258,7 +3273,7 @@
                            "rcsb_search_group": [
                               {
                                  "group_name": "Polymer Molecular Features",
-                                 "priority_order": 125
+                                 "priority_order": 135
                               }
                            ]
                         }
@@ -3584,6 +3599,16 @@
                   {
                      "text": "The BIRD identifier for the entity in this container.",
                      "context": "dictionary"
+                  },
+                  {
+                     "text": "Polymer BIRD ID",
+                     "context": "brief"
+                  }
+               ],
+               "rcsb_search_group": [
+                  {
+                     "group_name": "Polymer Molecular Features",
+                     "priority_order": 95
                   }
                ]
             },
@@ -3772,7 +3797,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 145
+                              "priority_order": 155
                            }
                         ]
                      },
@@ -3819,7 +3844,7 @@
                         "rcsb_search_group": [
                            {
                               "group_name": "Polymer Molecular Features",
-                              "priority_order": 140
+                              "priority_order": 150
                            }
                         ]
                      }
@@ -4318,7 +4343,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 130
+                        "priority_order": 140
                      }
                   ]
                },
@@ -4345,7 +4370,7 @@
                   "rcsb_search_group": [
                      {
                         "group_name": "Polymer Molecular Features",
-                        "priority_order": 135
+                        "priority_order": 145
                      }
                   ]
                },


### PR DESCRIPTION
This PR addresses RO-4688 and RO-4904. 

 - RO-4688: Add search metadata for `entity_src_gen.gene_src_strain`
 - RO-4904: Add search UI metadata for `rcsb_polymer_entity_container_identifiers.prd_id`, `rcsb_nonpolymer_entity_container_identifiers.prd_id`, and `rcsb_branched_entity_container_identifiers.prd_id`